### PR TITLE
Add discrete ACAS Xu contract results (all 5 NNs: 1659 SAT, 791 UNSAT)

### DIFF
--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_clear_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_clear_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 1,
+  "onnx_path": "networks/aprev_clear.onnx",
+  "mode": "discrete, EPS=0.0, timeout=60.0s per state",
+  "timestamp": "2026-04-14T20:23:47.181398",
+  "timeout_sec": 3600,
+  "total_wall_sec": 133.9,
+  "avg_sat_sec": 0.499,
+  "summary": {
+    "SAT": 311,
+    "UNSAT": 179,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 1,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.809,
+      "status": "SAT"
+    },
+    {
+      "id": 6,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.36,
+      "status": "SAT"
+    },
+    {
+      "id": 11,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 2.299,
+      "status": "UNSAT"
+    },
+    {
+      "id": 16,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 21,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 26,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.274,
+      "status": "SAT"
+    },
+    {
+      "id": 31,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.284,
+      "status": "SAT"
+    },
+    {
+      "id": 36,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 41,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.137,
+      "status": "UNSAT"
+    },
+    {
+      "id": 46,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.269,
+      "status": "SAT"
+    },
+    {
+      "id": 51,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.322,
+      "status": "SAT"
+    },
+    {
+      "id": 56,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.308,
+      "status": "SAT"
+    },
+    {
+      "id": 61,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.597,
+      "status": "UNSAT"
+    },
+    {
+      "id": 66,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 71,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.278,
+      "status": "SAT"
+    },
+    {
+      "id": 76,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.26,
+      "status": "SAT"
+    },
+    {
+      "id": 81,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.269,
+      "status": "SAT"
+    },
+    {
+      "id": 86,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 91,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.118,
+      "status": "UNSAT"
+    },
+    {
+      "id": 96,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.273,
+      "status": "SAT"
+    },
+    {
+      "id": 101,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 106,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.274,
+      "status": "SAT"
+    },
+    {
+      "id": 111,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "UNSAT"
+    },
+    {
+      "id": 116,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 121,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.281,
+      "status": "SAT"
+    },
+    {
+      "id": 126,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.316,
+      "status": "SAT"
+    },
+    {
+      "id": 131,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.276,
+      "status": "SAT"
+    },
+    {
+      "id": 136,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.538,
+      "status": "UNSAT"
+    },
+    {
+      "id": 141,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 146,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.304,
+      "status": "SAT"
+    },
+    {
+      "id": 151,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 156,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 161,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.332,
+      "status": "SAT"
+    },
+    {
+      "id": 166,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 171,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.309,
+      "status": "SAT"
+    },
+    {
+      "id": 176,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.398,
+      "status": "SAT"
+    },
+    {
+      "id": 181,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "UNSAT"
+    },
+    {
+      "id": 186,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 191,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.308,
+      "status": "SAT"
+    },
+    {
+      "id": 196,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.321,
+      "status": "SAT"
+    },
+    {
+      "id": 201,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 206,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 211,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 216,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.455,
+      "status": "SAT"
+    },
+    {
+      "id": 221,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.258,
+      "status": "SAT"
+    },
+    {
+      "id": 226,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.556,
+      "status": "UNSAT"
+    },
+    {
+      "id": 231,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 236,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 3.273,
+      "status": "UNSAT"
+    },
+    {
+      "id": 241,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 246,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.293,
+      "status": "SAT"
+    },
+    {
+      "id": 251,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 256,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 1.095,
+      "status": "UNSAT"
+    },
+    {
+      "id": 261,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.62,
+      "status": "SAT"
+    },
+    {
+      "id": 266,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.505,
+      "status": "SAT"
+    },
+    {
+      "id": 271,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.565,
+      "status": "UNSAT"
+    },
+    {
+      "id": 276,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.581,
+      "status": "UNSAT"
+    },
+    {
+      "id": 281,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 5.217,
+      "status": "UNSAT"
+    },
+    {
+      "id": 286,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 291,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 296,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.269,
+      "status": "SAT"
+    },
+    {
+      "id": 301,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 306,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.365,
+      "status": "SAT"
+    },
+    {
+      "id": 311,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.299,
+      "status": "SAT"
+    },
+    {
+      "id": 316,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 321,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.307,
+      "status": "SAT"
+    },
+    {
+      "id": 326,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 5.16,
+      "status": "UNSAT"
+    },
+    {
+      "id": 331,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.278,
+      "status": "SAT"
+    },
+    {
+      "id": 336,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 341,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.3,
+      "status": "SAT"
+    },
+    {
+      "id": 346,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 351,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.31,
+      "status": "SAT"
+    },
+    {
+      "id": 356,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.35,
+      "status": "SAT"
+    },
+    {
+      "id": 361,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 366,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.432,
+      "status": "SAT"
+    },
+    {
+      "id": 371,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 4.12,
+      "status": "UNSAT"
+    },
+    {
+      "id": 376,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.306,
+      "status": "SAT"
+    },
+    {
+      "id": 381,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.256,
+      "status": "SAT"
+    },
+    {
+      "id": 386,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 391,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.333,
+      "status": "SAT"
+    },
+    {
+      "id": 396,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.252,
+      "status": "SAT"
+    },
+    {
+      "id": 401,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.245,
+      "status": "SAT"
+    },
+    {
+      "id": 406,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.278,
+      "status": "SAT"
+    },
+    {
+      "id": 411,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 416,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.339,
+      "status": "SAT"
+    },
+    {
+      "id": 421,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 4.666,
+      "status": "UNSAT"
+    },
+    {
+      "id": 426,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 431,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 436,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 441,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 446,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.287,
+      "status": "SAT"
+    },
+    {
+      "id": 451,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.37,
+      "status": "SAT"
+    },
+    {
+      "id": 456,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.25,
+      "status": "SAT"
+    },
+    {
+      "id": 461,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 466,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.244,
+      "status": "SAT"
+    },
+    {
+      "id": 471,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 2.593,
+      "status": "UNSAT"
+    },
+    {
+      "id": 476,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.304,
+      "status": "SAT"
+    },
+    {
+      "id": 481,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "SAT"
+    },
+    {
+      "id": 486,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 491,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.285,
+      "status": "SAT"
+    },
+    {
+      "id": 496,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 1.089,
+      "status": "UNSAT"
+    },
+    {
+      "id": 501,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.405,
+      "status": "SAT"
+    },
+    {
+      "id": 506,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.95,
+      "status": "SAT"
+    },
+    {
+      "id": 511,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 516,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.262,
+      "status": "SAT"
+    },
+    {
+      "id": 521,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.087,
+      "status": "UNSAT"
+    },
+    {
+      "id": 526,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.333,
+      "status": "SAT"
+    },
+    {
+      "id": 531,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "SAT"
+    },
+    {
+      "id": 536,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 541,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.581,
+      "status": "SAT"
+    },
+    {
+      "id": 546,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 1.02,
+      "status": "UNSAT"
+    },
+    {
+      "id": 551,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.316,
+      "status": "SAT"
+    },
+    {
+      "id": 556,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.937,
+      "status": "SAT"
+    },
+    {
+      "id": 561,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 566,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.923,
+      "status": "SAT"
+    },
+    {
+      "id": 571,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 576,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.636,
+      "status": "SAT"
+    },
+    {
+      "id": 581,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.577,
+      "status": "SAT"
+    },
+    {
+      "id": 586,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 591,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.552,
+      "status": "SAT"
+    },
+    {
+      "id": 596,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 1.062,
+      "status": "UNSAT"
+    },
+    {
+      "id": 601,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.021,
+      "status": "SAT"
+    },
+    {
+      "id": 606,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.957,
+      "status": "SAT"
+    },
+    {
+      "id": 611,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 616,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.957,
+      "status": "SAT"
+    },
+    {
+      "id": 621,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.12,
+      "status": "UNSAT"
+    },
+    {
+      "id": 626,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.613,
+      "status": "SAT"
+    },
+    {
+      "id": 631,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.557,
+      "status": "SAT"
+    },
+    {
+      "id": 636,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 641,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.586,
+      "status": "SAT"
+    },
+    {
+      "id": 646,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 2.846,
+      "status": "UNSAT"
+    },
+    {
+      "id": 651,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.026,
+      "status": "SAT"
+    },
+    {
+      "id": 656,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.909,
+      "status": "SAT"
+    },
+    {
+      "id": 661,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 666,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.877,
+      "status": "SAT"
+    },
+    {
+      "id": 671,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.92,
+      "status": "SAT"
+    },
+    {
+      "id": 676,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.507,
+      "status": "SAT"
+    },
+    {
+      "id": 681,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.405,
+      "status": "SAT"
+    },
+    {
+      "id": 686,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 691,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 696,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 2.689,
+      "status": "UNSAT"
+    },
+    {
+      "id": 701,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 706,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.893,
+      "status": "SAT"
+    },
+    {
+      "id": 711,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.729,
+      "status": "SAT"
+    },
+    {
+      "id": 716,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 721,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.896,
+      "status": "SAT"
+    },
+    {
+      "id": 726,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 4.187,
+      "status": "UNSAT"
+    },
+    {
+      "id": 731,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.628,
+      "status": "SAT"
+    },
+    {
+      "id": 736,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.342,
+      "status": "SAT"
+    },
+    {
+      "id": 741,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 746,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.446,
+      "status": "SAT"
+    },
+    {
+      "id": 751,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "SAT"
+    },
+    {
+      "id": 756,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 761,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 766,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.927,
+      "status": "SAT"
+    },
+    {
+      "id": 771,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.757,
+      "status": "SAT"
+    },
+    {
+      "id": 776,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 781,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.743,
+      "status": "SAT"
+    },
+    {
+      "id": 786,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 4.192,
+      "status": "UNSAT"
+    },
+    {
+      "id": 791,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.389,
+      "status": "SAT"
+    },
+    {
+      "id": 796,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.398,
+      "status": "SAT"
+    },
+    {
+      "id": 801,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 806,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.438,
+      "status": "SAT"
+    },
+    {
+      "id": 811,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 1.044,
+      "status": "UNSAT"
+    },
+    {
+      "id": 816,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 821,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.103,
+      "status": "SAT"
+    },
+    {
+      "id": 826,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 831,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.602,
+      "status": "UNSAT"
+    },
+    {
+      "id": 836,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.832,
+      "status": "SAT"
+    },
+    {
+      "id": 841,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 846,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.722,
+      "status": "SAT"
+    },
+    {
+      "id": 851,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.167,
+      "status": "UNSAT"
+    },
+    {
+      "id": 856,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.441,
+      "status": "SAT"
+    },
+    {
+      "id": 861,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.348,
+      "status": "SAT"
+    },
+    {
+      "id": 866,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 871,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.374,
+      "status": "SAT"
+    },
+    {
+      "id": 876,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.369,
+      "status": "SAT"
+    },
+    {
+      "id": 881,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 886,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 891,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 896,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 901,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 3.222,
+      "status": "UNSAT"
+    },
+    {
+      "id": 906,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.732,
+      "status": "SAT"
+    },
+    {
+      "id": 911,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 916,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.773,
+      "status": "SAT"
+    },
+    {
+      "id": 921,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.716,
+      "status": "SAT"
+    },
+    {
+      "id": 926,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 931,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.361,
+      "status": "SAT"
+    },
+    {
+      "id": 936,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 941,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.36,
+      "status": "SAT"
+    },
+    {
+      "id": 946,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.511,
+      "status": "UNSAT"
+    },
+    {
+      "id": 951,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 956,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 961,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 966,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.128,
+      "status": "SAT"
+    },
+    {
+      "id": 971,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.122,
+      "status": "SAT"
+    },
+    {
+      "id": 976,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.69,
+      "status": "SAT"
+    },
+    {
+      "id": 981,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.718,
+      "status": "SAT"
+    },
+    {
+      "id": 986,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 991,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.931,
+      "status": "SAT"
+    },
+    {
+      "id": 996,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.624,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1001,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1006,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.431,
+      "status": "SAT"
+    },
+    {
+      "id": 1011,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.139,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1016,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.392,
+      "status": "SAT"
+    },
+    {
+      "id": 1021,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.357,
+      "status": "SAT"
+    },
+    {
+      "id": 1026,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1031,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1036,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.12,
+      "status": "SAT"
+    },
+    {
+      "id": 1041,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1046,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1051,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1056,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.715,
+      "status": "SAT"
+    },
+    {
+      "id": 1061,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1066,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.807,
+      "status": "SAT"
+    },
+    {
+      "id": 1071,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.107,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1076,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.979,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1081,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 1086,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1091,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.391,
+      "status": "SAT"
+    },
+    {
+      "id": 1096,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.376,
+      "status": "SAT"
+    },
+    {
+      "id": 1101,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1106,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1111,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1116,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1121,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1126,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.539,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1131,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.447,
+      "status": "SAT"
+    },
+    {
+      "id": 1136,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1141,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.745,
+      "status": "SAT"
+    },
+    {
+      "id": 1146,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.12,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1151,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1156,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.227,
+      "status": "SAT"
+    },
+    {
+      "id": 1161,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1166,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.192,
+      "status": "SAT"
+    },
+    {
+      "id": 1171,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.359,
+      "status": "SAT"
+    },
+    {
+      "id": 1176,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1181,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 1186,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.097,
+      "status": "SAT"
+    },
+    {
+      "id": 1191,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.512,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1196,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1201,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.628,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1206,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.45,
+      "status": "SAT"
+    },
+    {
+      "id": 1211,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1216,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "SAT"
+    },
+    {
+      "id": 1221,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.074,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1226,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1231,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.232,
+      "status": "SAT"
+    },
+    {
+      "id": 1236,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1241,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.237,
+      "status": "SAT"
+    },
+    {
+      "id": 1246,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.368,
+      "status": "SAT"
+    },
+    {
+      "id": 1251,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.196,
+      "status": "SAT"
+    },
+    {
+      "id": 1256,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.218,
+      "status": "SAT"
+    },
+    {
+      "id": 1261,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 1266,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1271,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 1276,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.575,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1281,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.481,
+      "status": "SAT"
+    },
+    {
+      "id": 1286,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1291,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1296,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.805,
+      "status": "SAT"
+    },
+    {
+      "id": 1301,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1306,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1311,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.575,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1316,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 1321,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1326,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1331,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1336,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.131,
+      "status": "SAT"
+    },
+    {
+      "id": 1341,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1346,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.229,
+      "status": "SAT"
+    },
+    {
+      "id": 1351,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1356,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "SAT"
+    },
+    {
+      "id": 1361,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1366,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.128,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1371,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.615,
+      "status": "SAT"
+    },
+    {
+      "id": 1376,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1381,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.223,
+      "status": "SAT"
+    },
+    {
+      "id": 1386,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1391,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1396,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.22,
+      "status": "SAT"
+    },
+    {
+      "id": 1401,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1406,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1411,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.24,
+      "status": "SAT"
+    },
+    {
+      "id": 1416,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 1421,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1426,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1431,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.187,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1436,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.457,
+      "status": "SAT"
+    },
+    {
+      "id": 1441,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.631,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1446,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.477,
+      "status": "SAT"
+    },
+    {
+      "id": 1451,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1456,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 1461,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.57,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1466,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.246,
+      "status": "SAT"
+    },
+    {
+      "id": 1471,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1476,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1481,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1486,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.232,
+      "status": "SAT"
+    },
+    {
+      "id": 1491,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.192,
+      "status": "SAT"
+    },
+    {
+      "id": 1496,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1501,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1506,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1511,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.561,
+      "status": "SAT"
+    },
+    {
+      "id": 1516,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.448,
+      "status": "SAT"
+    },
+    {
+      "id": 1521,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.46,
+      "status": "SAT"
+    },
+    {
+      "id": 1526,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1531,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.226,
+      "status": "SAT"
+    },
+    {
+      "id": 1536,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1541,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 1546,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1551,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1556,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1561,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 1566,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.192,
+      "status": "SAT"
+    },
+    {
+      "id": 1571,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.199,
+      "status": "SAT"
+    },
+    {
+      "id": 1576,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1581,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.546,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1586,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 1591,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.466,
+      "status": "SAT"
+    },
+    {
+      "id": 1596,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.47,
+      "status": "SAT"
+    },
+    {
+      "id": 1601,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.563,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1606,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1611,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.22,
+      "status": "SAT"
+    },
+    {
+      "id": 1616,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1621,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1626,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1631,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1636,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.283,
+      "status": "SAT"
+    },
+    {
+      "id": 1641,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1646,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1651,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.434,
+      "status": "SAT"
+    },
+    {
+      "id": 1656,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1661,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.522,
+      "status": "SAT"
+    },
+    {
+      "id": 1666,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.451,
+      "status": "SAT"
+    },
+    {
+      "id": 1671,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.445,
+      "status": "SAT"
+    },
+    {
+      "id": 1676,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1681,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1686,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.246,
+      "status": "SAT"
+    },
+    {
+      "id": 1691,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.109,
+      "status": "SAT"
+    },
+    {
+      "id": 1696,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 1701,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1706,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1711,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 1716,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.44,
+      "status": "SAT"
+    },
+    {
+      "id": 1721,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.223,
+      "status": "SAT"
+    },
+    {
+      "id": 1726,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "SAT"
+    },
+    {
+      "id": 1731,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1736,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.5,
+      "status": "SAT"
+    },
+    {
+      "id": 1741,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.702,
+      "status": "SAT"
+    },
+    {
+      "id": 1746,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.421,
+      "status": "SAT"
+    },
+    {
+      "id": 1751,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1756,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1761,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.221,
+      "status": "SAT"
+    },
+    {
+      "id": 1766,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.082,
+      "status": "SAT"
+    },
+    {
+      "id": 1771,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1776,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.359,
+      "status": "SAT"
+    },
+    {
+      "id": 1781,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1786,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 1791,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.424,
+      "status": "SAT"
+    },
+    {
+      "id": 1796,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1801,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.802,
+      "status": "SAT"
+    },
+    {
+      "id": 1806,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1811,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.514,
+      "status": "SAT"
+    },
+    {
+      "id": 1816,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.701,
+      "status": "SAT"
+    },
+    {
+      "id": 1821,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.444,
+      "status": "SAT"
+    },
+    {
+      "id": 1826,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1831,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1836,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.25,
+      "status": "SAT"
+    },
+    {
+      "id": 1841,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.095,
+      "status": "SAT"
+    },
+    {
+      "id": 1846,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.102,
+      "status": "SAT"
+    },
+    {
+      "id": 1851,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.363,
+      "status": "SAT"
+    },
+    {
+      "id": 1856,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1861,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.252,
+      "status": "SAT"
+    },
+    {
+      "id": 1866,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1871,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 1876,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 1881,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1886,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.566,
+      "status": "SAT"
+    },
+    {
+      "id": 1891,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.729,
+      "status": "SAT"
+    },
+    {
+      "id": 1896,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.725,
+      "status": "SAT"
+    },
+    {
+      "id": 1901,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1906,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1911,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.128,
+      "status": "SAT"
+    },
+    {
+      "id": 1916,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.114,
+      "status": "SAT"
+    },
+    {
+      "id": 1921,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1926,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.36,
+      "status": "SAT"
+    },
+    {
+      "id": 1931,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1936,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.663,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1941,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1946,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.389,
+      "status": "SAT"
+    },
+    {
+      "id": 1951,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.753,
+      "status": "SAT"
+    },
+    {
+      "id": 1956,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1961,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.864,
+      "status": "SAT"
+    },
+    {
+      "id": 1966,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.755,
+      "status": "SAT"
+    },
+    {
+      "id": 1971,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.796,
+      "status": "SAT"
+    },
+    {
+      "id": 1976,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.112,
+      "status": "SAT"
+    },
+    {
+      "id": 1981,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1986,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.164,
+      "status": "SAT"
+    },
+    {
+      "id": 1991,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 1996,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.115,
+      "status": "SAT"
+    },
+    {
+      "id": 2001,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.449,
+      "status": "SAT"
+    },
+    {
+      "id": 2006,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2011,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.669,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2016,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2021,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.391,
+      "status": "SAT"
+    },
+    {
+      "id": 2026,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.757,
+      "status": "SAT"
+    },
+    {
+      "id": 2031,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2036,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.791,
+      "status": "SAT"
+    },
+    {
+      "id": 2041,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.772,
+      "status": "SAT"
+    },
+    {
+      "id": 2046,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.781,
+      "status": "SAT"
+    },
+    {
+      "id": 2051,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 2056,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 2061,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 2066,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.106,
+      "status": "SAT"
+    },
+    {
+      "id": 2071,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.39,
+      "status": "SAT"
+    },
+    {
+      "id": 2076,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.617,
+      "status": "SAT"
+    },
+    {
+      "id": 2081,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.051,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2086,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2091,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.449,
+      "status": "SAT"
+    },
+    {
+      "id": 2096,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.745,
+      "status": "SAT"
+    },
+    {
+      "id": 2101,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2106,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 2.662,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2111,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.141,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2116,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.76,
+      "status": "SAT"
+    },
+    {
+      "id": 2121,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 2126,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 2131,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2136,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 2141,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.544,
+      "status": "SAT"
+    },
+    {
+      "id": 2146,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.079,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2151,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2156,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.385,
+      "status": "SAT"
+    },
+    {
+      "id": 2161,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.734,
+      "status": "SAT"
+    },
+    {
+      "id": 2166,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2171,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 2.94,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2176,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.56,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2181,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.723,
+      "status": "SAT"
+    },
+    {
+      "id": 2186,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2191,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 2196,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.562,
+      "status": "SAT"
+    },
+    {
+      "id": 2201,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.557,
+      "status": "SAT"
+    },
+    {
+      "id": 2206,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.2,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2211,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2216,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.574,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2221,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.924,
+      "status": "SAT"
+    },
+    {
+      "id": 2226,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2231,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 2.636,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2236,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2241,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.753,
+      "status": "SAT"
+    },
+    {
+      "id": 2246,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 2251,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.55,
+      "status": "SAT"
+    },
+    {
+      "id": 2256,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.614,
+      "status": "SAT"
+    },
+    {
+      "id": 2261,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2266,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 1.631,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2271,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.595,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2276,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.948,
+      "status": "SAT"
+    },
+    {
+      "id": 2281,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2286,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.047,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2291,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.594,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2296,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.927,
+      "status": "SAT"
+    },
+    {
+      "id": 2301,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.562,
+      "status": "SAT"
+    },
+    {
+      "id": 2306,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 2311,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2316,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 1.049,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2321,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.506,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2326,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.931,
+      "status": "SAT"
+    },
+    {
+      "id": 2331,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2336,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.523,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2341,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.914,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2346,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.902,
+      "status": "SAT"
+    },
+    {
+      "id": 2351,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "SAT"
+    },
+    {
+      "id": 2356,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.287,
+      "status": "SAT"
+    },
+    {
+      "id": 2361,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.538,
+      "status": "SAT"
+    },
+    {
+      "id": 2366,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2371,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 2.093,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2376,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.882,
+      "status": "SAT"
+    },
+    {
+      "id": 2381,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.248,
+      "status": "SAT"
+    },
+    {
+      "id": 2386,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2391,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.53,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2396,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 3.849,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2401,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.29,
+      "status": "SAT"
+    },
+    {
+      "id": 2406,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 2411,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 2.052,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2416,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2421,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.542,
+      "status": "SAT"
+    },
+    {
+      "id": 2426,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.29,
+      "status": "SAT"
+    },
+    {
+      "id": 2431,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.222,
+      "status": "SAT"
+    },
+    {
+      "id": 2436,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2441,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.516,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2446,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.905,
+      "status": "SAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_strong_left_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_strong_left_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 5,
+  "onnx_path": "networks/aprev_strong_left.onnx",
+  "mode": "discrete, EPS=0.0, timeout=60.0s per state",
+  "timestamp": "2026-04-14T20:28:20.414946",
+  "timeout_sec": 3600,
+  "total_wall_sec": 62.985,
+  "avg_sat_sec": 0.503,
+  "summary": {
+    "SAT": 342,
+    "UNSAT": 148,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 5,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.751,
+      "status": "SAT"
+    },
+    {
+      "id": 10,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.282,
+      "status": "SAT"
+    },
+    {
+      "id": 15,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "SAT"
+    },
+    {
+      "id": 20,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "UNSAT"
+    },
+    {
+      "id": 25,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 30,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 35,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.348,
+      "status": "SAT"
+    },
+    {
+      "id": 40,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.894,
+      "status": "SAT"
+    },
+    {
+      "id": 45,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.299,
+      "status": "UNSAT"
+    },
+    {
+      "id": 50,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.292,
+      "status": "SAT"
+    },
+    {
+      "id": 55,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 60,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.26,
+      "status": "SAT"
+    },
+    {
+      "id": 65,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.258,
+      "status": "SAT"
+    },
+    {
+      "id": 70,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 75,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.318,
+      "status": "SAT"
+    },
+    {
+      "id": 80,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 85,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.342,
+      "status": "SAT"
+    },
+    {
+      "id": 90,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.245,
+      "status": "SAT"
+    },
+    {
+      "id": 95,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.076,
+      "status": "UNSAT"
+    },
+    {
+      "id": 100,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.253,
+      "status": "SAT"
+    },
+    {
+      "id": 105,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 110,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.272,
+      "status": "SAT"
+    },
+    {
+      "id": 115,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 120,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 125,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.368,
+      "status": "SAT"
+    },
+    {
+      "id": 130,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 135,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.248,
+      "status": "SAT"
+    },
+    {
+      "id": 140,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.242,
+      "status": "SAT"
+    },
+    {
+      "id": 145,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.068,
+      "status": "UNSAT"
+    },
+    {
+      "id": 150,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.345,
+      "status": "SAT"
+    },
+    {
+      "id": 155,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 160,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 165,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "UNSAT"
+    },
+    {
+      "id": 170,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.312,
+      "status": "SAT"
+    },
+    {
+      "id": 175,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 180,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.339,
+      "status": "SAT"
+    },
+    {
+      "id": 185,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.257,
+      "status": "SAT"
+    },
+    {
+      "id": 190,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.556,
+      "status": "UNSAT"
+    },
+    {
+      "id": 195,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.337,
+      "status": "SAT"
+    },
+    {
+      "id": 200,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 205,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.287,
+      "status": "SAT"
+    },
+    {
+      "id": 210,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.261,
+      "status": "SAT"
+    },
+    {
+      "id": 215,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.274,
+      "status": "SAT"
+    },
+    {
+      "id": 220,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 225,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.257,
+      "status": "SAT"
+    },
+    {
+      "id": 230,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.285,
+      "status": "SAT"
+    },
+    {
+      "id": 235,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.6,
+      "status": "UNSAT"
+    },
+    {
+      "id": 240,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.343,
+      "status": "SAT"
+    },
+    {
+      "id": 245,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 250,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.261,
+      "status": "SAT"
+    },
+    {
+      "id": 255,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.274,
+      "status": "SAT"
+    },
+    {
+      "id": 260,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 265,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.536,
+      "status": "UNSAT"
+    },
+    {
+      "id": 270,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.228,
+      "status": "SAT"
+    },
+    {
+      "id": 275,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.285,
+      "status": "SAT"
+    },
+    {
+      "id": 280,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.509,
+      "status": "UNSAT"
+    },
+    {
+      "id": 285,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.309,
+      "status": "SAT"
+    },
+    {
+      "id": 290,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 295,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 300,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 305,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 310,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 315,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.243,
+      "status": "SAT"
+    },
+    {
+      "id": 320,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.259,
+      "status": "SAT"
+    },
+    {
+      "id": 325,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.652,
+      "status": "UNSAT"
+    },
+    {
+      "id": 330,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.436,
+      "status": "SAT"
+    },
+    {
+      "id": 335,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 340,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.314,
+      "status": "SAT"
+    },
+    {
+      "id": 345,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 350,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.297,
+      "status": "SAT"
+    },
+    {
+      "id": 355,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 360,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.262,
+      "status": "SAT"
+    },
+    {
+      "id": 365,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.338,
+      "status": "SAT"
+    },
+    {
+      "id": 370,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.672,
+      "status": "UNSAT"
+    },
+    {
+      "id": 375,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.305,
+      "status": "SAT"
+    },
+    {
+      "id": 380,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 385,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.316,
+      "status": "SAT"
+    },
+    {
+      "id": 390,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 395,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 400,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.275,
+      "status": "SAT"
+    },
+    {
+      "id": 405,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 410,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.264,
+      "status": "SAT"
+    },
+    {
+      "id": 415,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.224,
+      "status": "SAT"
+    },
+    {
+      "id": 420,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.641,
+      "status": "UNSAT"
+    },
+    {
+      "id": 425,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.343,
+      "status": "SAT"
+    },
+    {
+      "id": 430,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.301,
+      "status": "SAT"
+    },
+    {
+      "id": 435,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 440,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.278,
+      "status": "SAT"
+    },
+    {
+      "id": 445,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 450,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.381,
+      "status": "SAT"
+    },
+    {
+      "id": 455,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.233,
+      "status": "SAT"
+    },
+    {
+      "id": 460,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.256,
+      "status": "SAT"
+    },
+    {
+      "id": 465,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.238,
+      "status": "SAT"
+    },
+    {
+      "id": 470,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 475,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.333,
+      "status": "SAT"
+    },
+    {
+      "id": 480,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 485,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 490,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.269,
+      "status": "SAT"
+    },
+    {
+      "id": 495,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 500,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.299,
+      "status": "SAT"
+    },
+    {
+      "id": 505,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.27,
+      "status": "SAT"
+    },
+    {
+      "id": 510,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.89,
+      "status": "SAT"
+    },
+    {
+      "id": 515,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.27,
+      "status": "SAT"
+    },
+    {
+      "id": 520,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 525,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.331,
+      "status": "SAT"
+    },
+    {
+      "id": 530,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 535,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 540,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 545,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 550,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.395,
+      "status": "SAT"
+    },
+    {
+      "id": 555,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.24,
+      "status": "SAT"
+    },
+    {
+      "id": 560,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.901,
+      "status": "SAT"
+    },
+    {
+      "id": 565,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.28,
+      "status": "SAT"
+    },
+    {
+      "id": 570,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 575,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.309,
+      "status": "SAT"
+    },
+    {
+      "id": 580,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "SAT"
+    },
+    {
+      "id": 585,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.547,
+      "status": "SAT"
+    },
+    {
+      "id": 590,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.26,
+      "status": "SAT"
+    },
+    {
+      "id": 595,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 600,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.311,
+      "status": "SAT"
+    },
+    {
+      "id": 605,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.894,
+      "status": "SAT"
+    },
+    {
+      "id": 610,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.899,
+      "status": "SAT"
+    },
+    {
+      "id": 615,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.251,
+      "status": "SAT"
+    },
+    {
+      "id": 620,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 625,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.422,
+      "status": "SAT"
+    },
+    {
+      "id": 630,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.538,
+      "status": "SAT"
+    },
+    {
+      "id": 635,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "SAT"
+    },
+    {
+      "id": 640,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.278,
+      "status": "SAT"
+    },
+    {
+      "id": 645,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 650,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.578,
+      "status": "SAT"
+    },
+    {
+      "id": 655,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.911,
+      "status": "SAT"
+    },
+    {
+      "id": 660,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 3.219,
+      "status": "UNSAT"
+    },
+    {
+      "id": 665,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.282,
+      "status": "SAT"
+    },
+    {
+      "id": 670,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 675,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.984,
+      "status": "SAT"
+    },
+    {
+      "id": 680,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.552,
+      "status": "SAT"
+    },
+    {
+      "id": 685,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.367,
+      "status": "SAT"
+    },
+    {
+      "id": 690,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 695,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 700,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.623,
+      "status": "SAT"
+    },
+    {
+      "id": 705,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 710,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.937,
+      "status": "SAT"
+    },
+    {
+      "id": 715,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.154,
+      "status": "UNSAT"
+    },
+    {
+      "id": 720,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.929,
+      "status": "SAT"
+    },
+    {
+      "id": 725,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 730,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.978,
+      "status": "SAT"
+    },
+    {
+      "id": 735,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "SAT"
+    },
+    {
+      "id": 740,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.349,
+      "status": "SAT"
+    },
+    {
+      "id": 745,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.575,
+      "status": "SAT"
+    },
+    {
+      "id": 750,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 755,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.592,
+      "status": "SAT"
+    },
+    {
+      "id": 760,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.097,
+      "status": "SAT"
+    },
+    {
+      "id": 765,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.11,
+      "status": "SAT"
+    },
+    {
+      "id": 770,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.9,
+      "status": "SAT"
+    },
+    {
+      "id": 775,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.605,
+      "status": "UNSAT"
+    },
+    {
+      "id": 780,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.88,
+      "status": "SAT"
+    },
+    {
+      "id": 785,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 790,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.995,
+      "status": "SAT"
+    },
+    {
+      "id": 795,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.376,
+      "status": "SAT"
+    },
+    {
+      "id": 800,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.364,
+      "status": "SAT"
+    },
+    {
+      "id": 805,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "SAT"
+    },
+    {
+      "id": 810,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.007,
+      "status": "UNSAT"
+    },
+    {
+      "id": 815,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.625,
+      "status": "SAT"
+    },
+    {
+      "id": 820,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 825,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 830,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 835,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.793,
+      "status": "SAT"
+    },
+    {
+      "id": 840,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.092,
+      "status": "UNSAT"
+    },
+    {
+      "id": 845,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.918,
+      "status": "SAT"
+    },
+    {
+      "id": 850,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 855,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.013,
+      "status": "SAT"
+    },
+    {
+      "id": 860,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.356,
+      "status": "SAT"
+    },
+    {
+      "id": 865,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.379,
+      "status": "SAT"
+    },
+    {
+      "id": 870,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.55,
+      "status": "SAT"
+    },
+    {
+      "id": 875,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 880,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.396,
+      "status": "SAT"
+    },
+    {
+      "id": 885,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.095,
+      "status": "SAT"
+    },
+    {
+      "id": 890,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 895,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 900,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 905,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.613,
+      "status": "UNSAT"
+    },
+    {
+      "id": 910,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.555,
+      "status": "UNSAT"
+    },
+    {
+      "id": 915,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.929,
+      "status": "SAT"
+    },
+    {
+      "id": 920,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 925,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.783,
+      "status": "SAT"
+    },
+    {
+      "id": 930,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.355,
+      "status": "SAT"
+    },
+    {
+      "id": 935,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 940,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.337,
+      "status": "SAT"
+    },
+    {
+      "id": 945,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.086,
+      "status": "UNSAT"
+    },
+    {
+      "id": 950,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.404,
+      "status": "SAT"
+    },
+    {
+      "id": 955,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 960,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 965,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 970,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 975,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 980,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.603,
+      "status": "UNSAT"
+    },
+    {
+      "id": 985,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 990,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.799,
+      "status": "SAT"
+    },
+    {
+      "id": 995,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1000,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.773,
+      "status": "SAT"
+    },
+    {
+      "id": 1005,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 1010,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1015,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.444,
+      "status": "SAT"
+    },
+    {
+      "id": 1020,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 1025,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 1030,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.096,
+      "status": "SAT"
+    },
+    {
+      "id": 1035,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1040,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.131,
+      "status": "SAT"
+    },
+    {
+      "id": 1045,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.107,
+      "status": "SAT"
+    },
+    {
+      "id": 1050,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 1055,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1060,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1065,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.694,
+      "status": "SAT"
+    },
+    {
+      "id": 1070,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.609,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1075,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.711,
+      "status": "SAT"
+    },
+    {
+      "id": 1080,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.379,
+      "status": "SAT"
+    },
+    {
+      "id": 1085,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1090,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.395,
+      "status": "SAT"
+    },
+    {
+      "id": 1095,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 1100,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.364,
+      "status": "SAT"
+    },
+    {
+      "id": 1105,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1110,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1115,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1120,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1125,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1130,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.044,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1135,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1140,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.705,
+      "status": "SAT"
+    },
+    {
+      "id": 1145,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.737,
+      "status": "SAT"
+    },
+    {
+      "id": 1150,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.746,
+      "status": "SAT"
+    },
+    {
+      "id": 1155,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.367,
+      "status": "SAT"
+    },
+    {
+      "id": 1160,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1165,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.425,
+      "status": "SAT"
+    },
+    {
+      "id": 1170,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1175,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.418,
+      "status": "SAT"
+    },
+    {
+      "id": 1180,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1185,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1190,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1195,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1200,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1205,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.095,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1210,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1215,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.725,
+      "status": "SAT"
+    },
+    {
+      "id": 1220,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.451,
+      "status": "SAT"
+    },
+    {
+      "id": 1225,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.731,
+      "status": "SAT"
+    },
+    {
+      "id": 1230,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1235,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1240,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.428,
+      "status": "SAT"
+    },
+    {
+      "id": 1245,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 1250,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.361,
+      "status": "SAT"
+    },
+    {
+      "id": 1255,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1260,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1265,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 1270,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 1275,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.105,
+      "status": "SAT"
+    },
+    {
+      "id": 1280,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.007,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1285,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.164,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1290,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.743,
+      "status": "SAT"
+    },
+    {
+      "id": 1295,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.473,
+      "status": "SAT"
+    },
+    {
+      "id": 1300,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.758,
+      "status": "SAT"
+    },
+    {
+      "id": 1305,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1310,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.622,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1315,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.44,
+      "status": "SAT"
+    },
+    {
+      "id": 1320,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1325,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1330,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 1335,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1340,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 1345,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1350,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1355,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1360,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.184,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1365,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.745,
+      "status": "SAT"
+    },
+    {
+      "id": 1370,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.442,
+      "status": "SAT"
+    },
+    {
+      "id": 1375,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.453,
+      "status": "SAT"
+    },
+    {
+      "id": 1380,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1385,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 1390,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1395,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1400,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1405,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.204,
+      "status": "SAT"
+    },
+    {
+      "id": 1410,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1415,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.24,
+      "status": "SAT"
+    },
+    {
+      "id": 1420,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1425,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1430,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1435,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1440,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.482,
+      "status": "SAT"
+    },
+    {
+      "id": 1445,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.466,
+      "status": "SAT"
+    },
+    {
+      "id": 1450,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.443,
+      "status": "SAT"
+    },
+    {
+      "id": 1455,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1460,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.258,
+      "status": "SAT"
+    },
+    {
+      "id": 1465,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 1470,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1475,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1480,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1485,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1490,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.216,
+      "status": "SAT"
+    },
+    {
+      "id": 1495,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1500,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1505,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1510,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.563,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1515,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.492,
+      "status": "SAT"
+    },
+    {
+      "id": 1520,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.471,
+      "status": "SAT"
+    },
+    {
+      "id": 1525,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.458,
+      "status": "SAT"
+    },
+    {
+      "id": 1530,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1535,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1540,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 1545,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1550,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1555,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1560,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1565,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.227,
+      "status": "SAT"
+    },
+    {
+      "id": 1570,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.203,
+      "status": "SAT"
+    },
+    {
+      "id": 1575,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.194,
+      "status": "SAT"
+    },
+    {
+      "id": 1580,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.472,
+      "status": "SAT"
+    },
+    {
+      "id": 1585,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1590,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.495,
+      "status": "SAT"
+    },
+    {
+      "id": 1595,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.454,
+      "status": "SAT"
+    },
+    {
+      "id": 1600,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.449,
+      "status": "SAT"
+    },
+    {
+      "id": 1605,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1610,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1615,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.232,
+      "status": "SAT"
+    },
+    {
+      "id": 1620,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.196,
+      "status": "SAT"
+    },
+    {
+      "id": 1625,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.213,
+      "status": "SAT"
+    },
+    {
+      "id": 1630,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 1635,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1640,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.213,
+      "status": "SAT"
+    },
+    {
+      "id": 1645,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1650,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1655,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1660,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.56,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1665,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.561,
+      "status": "SAT"
+    },
+    {
+      "id": 1670,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 1675,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.518,
+      "status": "SAT"
+    },
+    {
+      "id": 1680,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1685,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.151,
+      "status": "SAT"
+    },
+    {
+      "id": 1690,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.197,
+      "status": "SAT"
+    },
+    {
+      "id": 1695,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1700,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1705,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.542,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1710,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1715,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 1720,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 1725,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.194,
+      "status": "SAT"
+    },
+    {
+      "id": 1730,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1735,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.511,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1740,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "SAT"
+    },
+    {
+      "id": 1745,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.709,
+      "status": "SAT"
+    },
+    {
+      "id": 1750,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.481,
+      "status": "SAT"
+    },
+    {
+      "id": 1755,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1760,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 1765,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.199,
+      "status": "SAT"
+    },
+    {
+      "id": 1770,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1775,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1780,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.552,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1785,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1790,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1795,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.374,
+      "status": "SAT"
+    },
+    {
+      "id": 1800,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1805,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1810,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.554,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1815,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.522,
+      "status": "SAT"
+    },
+    {
+      "id": 1820,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.692,
+      "status": "SAT"
+    },
+    {
+      "id": 1825,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.455,
+      "status": "SAT"
+    },
+    {
+      "id": 1830,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1835,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.148,
+      "status": "SAT"
+    },
+    {
+      "id": 1840,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1845,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.102,
+      "status": "SAT"
+    },
+    {
+      "id": 1850,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.098,
+      "status": "SAT"
+    },
+    {
+      "id": 1855,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.566,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1860,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1865,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1870,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 1875,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.337,
+      "status": "SAT"
+    },
+    {
+      "id": 1880,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1885,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.577,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1890,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.531,
+      "status": "SAT"
+    },
+    {
+      "id": 1895,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.715,
+      "status": "SAT"
+    },
+    {
+      "id": 1900,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.732,
+      "status": "SAT"
+    },
+    {
+      "id": 1905,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1910,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1915,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 1920,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1925,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1930,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1935,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.468,
+      "status": "SAT"
+    },
+    {
+      "id": 1940,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 1945,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.364,
+      "status": "SAT"
+    },
+    {
+      "id": 1950,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 1955,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.12,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1960,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1965,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.766,
+      "status": "SAT"
+    },
+    {
+      "id": 1970,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 1975,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.744,
+      "status": "SAT"
+    },
+    {
+      "id": 1980,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1985,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1990,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1995,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 2000,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 2005,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2010,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.402,
+      "status": "SAT"
+    },
+    {
+      "id": 2015,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.359,
+      "status": "SAT"
+    },
+    {
+      "id": 2020,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.356,
+      "status": "SAT"
+    },
+    {
+      "id": 2025,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 2030,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.09,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2035,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2040,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.802,
+      "status": "SAT"
+    },
+    {
+      "id": 2045,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.712,
+      "status": "SAT"
+    },
+    {
+      "id": 2050,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.792,
+      "status": "SAT"
+    },
+    {
+      "id": 2055,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.121,
+      "status": "SAT"
+    },
+    {
+      "id": 2060,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.105,
+      "status": "SAT"
+    },
+    {
+      "id": 2065,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.103,
+      "status": "SAT"
+    },
+    {
+      "id": 2070,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.12,
+      "status": "SAT"
+    },
+    {
+      "id": 2075,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2080,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.522,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2085,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.367,
+      "status": "SAT"
+    },
+    {
+      "id": 2090,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.366,
+      "status": "SAT"
+    },
+    {
+      "id": 2095,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.359,
+      "status": "SAT"
+    },
+    {
+      "id": 2100,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.004,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2105,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2110,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.813,
+      "status": "SAT"
+    },
+    {
+      "id": 2115,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.741,
+      "status": "SAT"
+    },
+    {
+      "id": 2120,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.764,
+      "status": "SAT"
+    },
+    {
+      "id": 2125,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 2130,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 2135,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 2140,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2145,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2150,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.402,
+      "status": "SAT"
+    },
+    {
+      "id": 2155,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "SAT"
+    },
+    {
+      "id": 2160,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.369,
+      "status": "SAT"
+    },
+    {
+      "id": 2165,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2170,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2175,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.761,
+      "status": "SAT"
+    },
+    {
+      "id": 2180,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.855,
+      "status": "SAT"
+    },
+    {
+      "id": 2185,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.739,
+      "status": "SAT"
+    },
+    {
+      "id": 2190,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.094,
+      "status": "SAT"
+    },
+    {
+      "id": 2195,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2200,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2205,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.52,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2210,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.413,
+      "status": "SAT"
+    },
+    {
+      "id": 2215,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "SAT"
+    },
+    {
+      "id": 2220,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 2225,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.507,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2230,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2235,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.723,
+      "status": "SAT"
+    },
+    {
+      "id": 2240,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.883,
+      "status": "SAT"
+    },
+    {
+      "id": 2245,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.719,
+      "status": "SAT"
+    },
+    {
+      "id": 2250,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.083,
+      "status": "SAT"
+    },
+    {
+      "id": 2255,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2260,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.528,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2265,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.395,
+      "status": "SAT"
+    },
+    {
+      "id": 2270,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "SAT"
+    },
+    {
+      "id": 2275,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.526,
+      "status": "SAT"
+    },
+    {
+      "id": 2280,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.502,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2285,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2290,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.714,
+      "status": "SAT"
+    },
+    {
+      "id": 2295,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.876,
+      "status": "SAT"
+    },
+    {
+      "id": 2300,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.892,
+      "status": "SAT"
+    },
+    {
+      "id": 2305,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2310,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.324,
+      "status": "SAT"
+    },
+    {
+      "id": 2315,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.529,
+      "status": "SAT"
+    },
+    {
+      "id": 2320,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 2325,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "SAT"
+    },
+    {
+      "id": 2330,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.509,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2335,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2340,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.908,
+      "status": "SAT"
+    },
+    {
+      "id": 2345,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.924,
+      "status": "SAT"
+    },
+    {
+      "id": 2350,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.616,
+      "status": "SAT"
+    },
+    {
+      "id": 2355,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2360,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.274,
+      "status": "SAT"
+    },
+    {
+      "id": 2365,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.547,
+      "status": "SAT"
+    },
+    {
+      "id": 2370,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.297,
+      "status": "SAT"
+    },
+    {
+      "id": 2375,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.593,
+      "status": "SAT"
+    },
+    {
+      "id": 2380,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2385,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.49,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2390,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.899,
+      "status": "SAT"
+    },
+    {
+      "id": 2395,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2400,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.892,
+      "status": "SAT"
+    },
+    {
+      "id": 2405,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.261,
+      "status": "SAT"
+    },
+    {
+      "id": 2410,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2415,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.568,
+      "status": "SAT"
+    },
+    {
+      "id": 2420,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2425,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 2430,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2435,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 2.999,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2440,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.879,
+      "status": "SAT"
+    },
+    {
+      "id": 2445,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.522,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2450,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.911,
+      "status": "SAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_strong_right_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_strong_right_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 4,
+  "onnx_path": "networks/aprev_strong_right.onnx",
+  "mode": "discrete, EPS=0.0, timeout=60.0s per state",
+  "timestamp": "2026-04-14T20:27:17.111054",
+  "timeout_sec": 3600,
+  "total_wall_sec": 60.567,
+  "avg_sat_sec": 0.52,
+  "summary": {
+    "SAT": 335,
+    "UNSAT": 155,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 4,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.808,
+      "status": "SAT"
+    },
+    {
+      "id": 9,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.314,
+      "status": "SAT"
+    },
+    {
+      "id": 14,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 1.085,
+      "status": "UNSAT"
+    },
+    {
+      "id": 19,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.332,
+      "status": "SAT"
+    },
+    {
+      "id": 24,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 29,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.322,
+      "status": "SAT"
+    },
+    {
+      "id": 34,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.241,
+      "status": "SAT"
+    },
+    {
+      "id": 39,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 44,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 49,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.052,
+      "status": "UNSAT"
+    },
+    {
+      "id": 54,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.272,
+      "status": "SAT"
+    },
+    {
+      "id": 59,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 64,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 1.099,
+      "status": "UNSAT"
+    },
+    {
+      "id": 69,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.302,
+      "status": "SAT"
+    },
+    {
+      "id": 74,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 79,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.25,
+      "status": "SAT"
+    },
+    {
+      "id": 84,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.271,
+      "status": "SAT"
+    },
+    {
+      "id": 89,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 94,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.323,
+      "status": "SAT"
+    },
+    {
+      "id": 99,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 104,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 109,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.269,
+      "status": "SAT"
+    },
+    {
+      "id": 114,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 119,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 124,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.318,
+      "status": "SAT"
+    },
+    {
+      "id": 129,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.396,
+      "status": "SAT"
+    },
+    {
+      "id": 134,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 139,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 144,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.318,
+      "status": "SAT"
+    },
+    {
+      "id": 149,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.54,
+      "status": "UNSAT"
+    },
+    {
+      "id": 154,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.274,
+      "status": "SAT"
+    },
+    {
+      "id": 159,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 164,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.303,
+      "status": "SAT"
+    },
+    {
+      "id": 169,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.257,
+      "status": "SAT"
+    },
+    {
+      "id": 174,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.257,
+      "status": "SAT"
+    },
+    {
+      "id": 179,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.374,
+      "status": "SAT"
+    },
+    {
+      "id": 184,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "UNSAT"
+    },
+    {
+      "id": 189,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.383,
+      "status": "SAT"
+    },
+    {
+      "id": 194,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 199,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.307,
+      "status": "SAT"
+    },
+    {
+      "id": 204,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 209,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 214,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.353,
+      "status": "SAT"
+    },
+    {
+      "id": 219,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.259,
+      "status": "SAT"
+    },
+    {
+      "id": 224,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.232,
+      "status": "SAT"
+    },
+    {
+      "id": 229,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "UNSAT"
+    },
+    {
+      "id": 234,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.434,
+      "status": "SAT"
+    },
+    {
+      "id": 239,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 244,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.27,
+      "status": "SAT"
+    },
+    {
+      "id": 249,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 254,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 259,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.324,
+      "status": "SAT"
+    },
+    {
+      "id": 264,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.36,
+      "status": "SAT"
+    },
+    {
+      "id": 269,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 274,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.063,
+      "status": "UNSAT"
+    },
+    {
+      "id": 279,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.316,
+      "status": "SAT"
+    },
+    {
+      "id": 284,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 289,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 294,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 299,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 304,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 309,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.305,
+      "status": "SAT"
+    },
+    {
+      "id": 314,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.323,
+      "status": "SAT"
+    },
+    {
+      "id": 319,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.165,
+      "status": "UNSAT"
+    },
+    {
+      "id": 324,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.32,
+      "status": "SAT"
+    },
+    {
+      "id": 329,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 334,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.308,
+      "status": "SAT"
+    },
+    {
+      "id": 339,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 344,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.27,
+      "status": "SAT"
+    },
+    {
+      "id": 349,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 354,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.319,
+      "status": "SAT"
+    },
+    {
+      "id": 359,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.24,
+      "status": "SAT"
+    },
+    {
+      "id": 364,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.66,
+      "status": "UNSAT"
+    },
+    {
+      "id": 369,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.358,
+      "status": "SAT"
+    },
+    {
+      "id": 374,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 379,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.307,
+      "status": "SAT"
+    },
+    {
+      "id": 384,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 389,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 394,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.273,
+      "status": "SAT"
+    },
+    {
+      "id": 399,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 404,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.34,
+      "status": "SAT"
+    },
+    {
+      "id": 409,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.375,
+      "status": "SAT"
+    },
+    {
+      "id": 414,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 3.156,
+      "status": "UNSAT"
+    },
+    {
+      "id": 419,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.328,
+      "status": "SAT"
+    },
+    {
+      "id": 424,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 429,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 434,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 439,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 444,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.305,
+      "status": "SAT"
+    },
+    {
+      "id": 449,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 454,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.328,
+      "status": "SAT"
+    },
+    {
+      "id": 459,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.276,
+      "status": "SAT"
+    },
+    {
+      "id": 464,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.765,
+      "status": "UNSAT"
+    },
+    {
+      "id": 469,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.577,
+      "status": "SAT"
+    },
+    {
+      "id": 474,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 479,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.263,
+      "status": "SAT"
+    },
+    {
+      "id": 484,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "SAT"
+    },
+    {
+      "id": 489,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.283,
+      "status": "SAT"
+    },
+    {
+      "id": 494,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 499,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 504,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.353,
+      "status": "SAT"
+    },
+    {
+      "id": 509,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.947,
+      "status": "SAT"
+    },
+    {
+      "id": 514,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.666,
+      "status": "UNSAT"
+    },
+    {
+      "id": 519,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.291,
+      "status": "SAT"
+    },
+    {
+      "id": 524,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 529,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 534,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.554,
+      "status": "SAT"
+    },
+    {
+      "id": 539,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 544,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.628,
+      "status": "SAT"
+    },
+    {
+      "id": 549,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "UNSAT"
+    },
+    {
+      "id": 554,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.269,
+      "status": "SAT"
+    },
+    {
+      "id": 559,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.907,
+      "status": "SAT"
+    },
+    {
+      "id": 564,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 569,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.963,
+      "status": "SAT"
+    },
+    {
+      "id": 574,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "UNSAT"
+    },
+    {
+      "id": 579,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.521,
+      "status": "SAT"
+    },
+    {
+      "id": 584,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.528,
+      "status": "SAT"
+    },
+    {
+      "id": 589,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 594,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.613,
+      "status": "SAT"
+    },
+    {
+      "id": 599,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.263,
+      "status": "SAT"
+    },
+    {
+      "id": 604,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.927,
+      "status": "SAT"
+    },
+    {
+      "id": 609,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.936,
+      "status": "SAT"
+    },
+    {
+      "id": 614,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 619,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.952,
+      "status": "SAT"
+    },
+    {
+      "id": 624,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.236,
+      "status": "SAT"
+    },
+    {
+      "id": 629,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.563,
+      "status": "SAT"
+    },
+    {
+      "id": 634,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "SAT"
+    },
+    {
+      "id": 639,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 644,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.601,
+      "status": "SAT"
+    },
+    {
+      "id": 649,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 1.609,
+      "status": "UNSAT"
+    },
+    {
+      "id": 654,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.893,
+      "status": "SAT"
+    },
+    {
+      "id": 659,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.908,
+      "status": "SAT"
+    },
+    {
+      "id": 664,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 669,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.998,
+      "status": "SAT"
+    },
+    {
+      "id": 674,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.907,
+      "status": "SAT"
+    },
+    {
+      "id": 679,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.541,
+      "status": "SAT"
+    },
+    {
+      "id": 684,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.354,
+      "status": "SAT"
+    },
+    {
+      "id": 689,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 694,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.601,
+      "status": "SAT"
+    },
+    {
+      "id": 699,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.524,
+      "status": "SAT"
+    },
+    {
+      "id": 704,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 709,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.956,
+      "status": "SAT"
+    },
+    {
+      "id": 714,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.716,
+      "status": "SAT"
+    },
+    {
+      "id": 719,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 724,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.962,
+      "status": "SAT"
+    },
+    {
+      "id": 729,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.896,
+      "status": "SAT"
+    },
+    {
+      "id": 734,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "SAT"
+    },
+    {
+      "id": 739,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.385,
+      "status": "SAT"
+    },
+    {
+      "id": 744,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 749,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.436,
+      "status": "SAT"
+    },
+    {
+      "id": 754,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.544,
+      "status": "SAT"
+    },
+    {
+      "id": 759,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 764,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 769,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.881,
+      "status": "SAT"
+    },
+    {
+      "id": 774,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.707,
+      "status": "SAT"
+    },
+    {
+      "id": 779,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 784,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.765,
+      "status": "SAT"
+    },
+    {
+      "id": 789,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.887,
+      "status": "SAT"
+    },
+    {
+      "id": 794,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 799,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.35,
+      "status": "SAT"
+    },
+    {
+      "id": 804,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 809,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.406,
+      "status": "SAT"
+    },
+    {
+      "id": 814,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.523,
+      "status": "SAT"
+    },
+    {
+      "id": 819,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.083,
+      "status": "SAT"
+    },
+    {
+      "id": 824,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 829,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 834,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.741,
+      "status": "SAT"
+    },
+    {
+      "id": 839,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.7,
+      "status": "SAT"
+    },
+    {
+      "id": 844,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 849,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.766,
+      "status": "SAT"
+    },
+    {
+      "id": 854,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 3.168,
+      "status": "UNSAT"
+    },
+    {
+      "id": 859,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.379,
+      "status": "SAT"
+    },
+    {
+      "id": 864,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.348,
+      "status": "SAT"
+    },
+    {
+      "id": 869,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 874,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.413,
+      "status": "SAT"
+    },
+    {
+      "id": 879,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.367,
+      "status": "SAT"
+    },
+    {
+      "id": 884,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 889,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 894,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 899,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 904,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.778,
+      "status": "SAT"
+    },
+    {
+      "id": 909,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.73,
+      "status": "SAT"
+    },
+    {
+      "id": 914,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 919,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.768,
+      "status": "SAT"
+    },
+    {
+      "id": 924,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.158,
+      "status": "UNSAT"
+    },
+    {
+      "id": 929,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.353,
+      "status": "SAT"
+    },
+    {
+      "id": 934,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.358,
+      "status": "SAT"
+    },
+    {
+      "id": 939,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 944,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.401,
+      "status": "SAT"
+    },
+    {
+      "id": 949,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "UNSAT"
+    },
+    {
+      "id": 954,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 959,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 964,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 969,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 974,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 979,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.792,
+      "status": "SAT"
+    },
+    {
+      "id": 984,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.721,
+      "status": "SAT"
+    },
+    {
+      "id": 989,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 994,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.755,
+      "status": "SAT"
+    },
+    {
+      "id": 999,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.614,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1004,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.438,
+      "status": "SAT"
+    },
+    {
+      "id": 1009,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 1014,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 1019,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 1024,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1029,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 1034,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1039,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1044,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1049,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1054,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.769,
+      "status": "SAT"
+    },
+    {
+      "id": 1059,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.736,
+      "status": "SAT"
+    },
+    {
+      "id": 1064,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.715,
+      "status": "SAT"
+    },
+    {
+      "id": 1069,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 1074,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1079,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.462,
+      "status": "SAT"
+    },
+    {
+      "id": 1084,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1089,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.369,
+      "status": "SAT"
+    },
+    {
+      "id": 1094,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.37,
+      "status": "SAT"
+    },
+    {
+      "id": 1099,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1104,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1109,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1114,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.11,
+      "status": "SAT"
+    },
+    {
+      "id": 1119,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.097,
+      "status": "SAT"
+    },
+    {
+      "id": 1124,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1129,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.806,
+      "status": "SAT"
+    },
+    {
+      "id": 1134,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.46,
+      "status": "SAT"
+    },
+    {
+      "id": 1139,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.706,
+      "status": "SAT"
+    },
+    {
+      "id": 1144,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.719,
+      "status": "SAT"
+    },
+    {
+      "id": 1149,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1154,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.406,
+      "status": "SAT"
+    },
+    {
+      "id": 1159,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1164,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.368,
+      "status": "SAT"
+    },
+    {
+      "id": 1169,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.576,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1174,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1179,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1184,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1189,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1194,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1199,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1204,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.837,
+      "status": "SAT"
+    },
+    {
+      "id": 1209,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.472,
+      "status": "SAT"
+    },
+    {
+      "id": 1214,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.692,
+      "status": "SAT"
+    },
+    {
+      "id": 1219,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.446,
+      "status": "SAT"
+    },
+    {
+      "id": 1224,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1229,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 1234,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1239,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 1244,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.56,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1249,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1254,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.253,
+      "status": "SAT"
+    },
+    {
+      "id": 1259,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1264,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.104,
+      "status": "SAT"
+    },
+    {
+      "id": 1269,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.523,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1274,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1279,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.483,
+      "status": "SAT"
+    },
+    {
+      "id": 1284,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.442,
+      "status": "SAT"
+    },
+    {
+      "id": 1289,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.728,
+      "status": "SAT"
+    },
+    {
+      "id": 1294,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.454,
+      "status": "SAT"
+    },
+    {
+      "id": 1299,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1304,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.224,
+      "status": "SAT"
+    },
+    {
+      "id": 1309,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1314,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.342,
+      "status": "SAT"
+    },
+    {
+      "id": 1319,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1324,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1329,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.252,
+      "status": "SAT"
+    },
+    {
+      "id": 1334,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1339,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1344,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.6,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1349,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1354,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.45,
+      "status": "SAT"
+    },
+    {
+      "id": 1359,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.439,
+      "status": "SAT"
+    },
+    {
+      "id": 1364,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 1369,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1374,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1379,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 1384,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1389,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1394,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1399,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1404,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.254,
+      "status": "SAT"
+    },
+    {
+      "id": 1409,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1414,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1419,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1424,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1429,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.466,
+      "status": "SAT"
+    },
+    {
+      "id": 1434,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.452,
+      "status": "SAT"
+    },
+    {
+      "id": 1439,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.431,
+      "status": "SAT"
+    },
+    {
+      "id": 1444,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.575,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1449,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1454,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.214,
+      "status": "SAT"
+    },
+    {
+      "id": 1459,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1464,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1469,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1474,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1479,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.254,
+      "status": "SAT"
+    },
+    {
+      "id": 1484,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1489,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1494,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1499,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1504,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.476,
+      "status": "SAT"
+    },
+    {
+      "id": 1509,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.449,
+      "status": "SAT"
+    },
+    {
+      "id": 1514,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.454,
+      "status": "SAT"
+    },
+    {
+      "id": 1519,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1524,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1529,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.22,
+      "status": "SAT"
+    },
+    {
+      "id": 1534,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1539,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 1544,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1549,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 1554,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1559,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1564,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1569,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1574,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.223,
+      "status": "SAT"
+    },
+    {
+      "id": 1579,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.437,
+      "status": "SAT"
+    },
+    {
+      "id": 1584,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.437,
+      "status": "SAT"
+    },
+    {
+      "id": 1589,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.467,
+      "status": "SAT"
+    },
+    {
+      "id": 1594,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1599,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.546,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1604,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.231,
+      "status": "SAT"
+    },
+    {
+      "id": 1609,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1614,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.192,
+      "status": "SAT"
+    },
+    {
+      "id": 1619,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.535,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1624,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1629,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1634,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.349,
+      "status": "SAT"
+    },
+    {
+      "id": 1639,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 1644,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1649,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.22,
+      "status": "SAT"
+    },
+    {
+      "id": 1654,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.463,
+      "status": "SAT"
+    },
+    {
+      "id": 1659,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.712,
+      "status": "SAT"
+    },
+    {
+      "id": 1664,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.461,
+      "status": "SAT"
+    },
+    {
+      "id": 1669,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.12,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1674,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1679,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.216,
+      "status": "SAT"
+    },
+    {
+      "id": 1684,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1689,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1694,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 1699,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1704,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1709,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 1714,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1719,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1724,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.53,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1729,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.528,
+      "status": "SAT"
+    },
+    {
+      "id": 1734,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.72,
+      "status": "SAT"
+    },
+    {
+      "id": 1739,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.439,
+      "status": "SAT"
+    },
+    {
+      "id": 1744,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.053,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1749,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1754,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1759,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1764,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1769,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 1774,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1779,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.408,
+      "status": "SAT"
+    },
+    {
+      "id": 1784,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.35,
+      "status": "SAT"
+    },
+    {
+      "id": 1789,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.513,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1794,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.066,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1799,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1804,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.694,
+      "status": "SAT"
+    },
+    {
+      "id": 1809,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.733,
+      "status": "SAT"
+    },
+    {
+      "id": 1814,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.423,
+      "status": "SAT"
+    },
+    {
+      "id": 1819,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 2.612,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1824,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1829,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 1834,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.098,
+      "status": "SAT"
+    },
+    {
+      "id": 1839,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.196,
+      "status": "SAT"
+    },
+    {
+      "id": 1844,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 1849,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1854,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.469,
+      "status": "SAT"
+    },
+    {
+      "id": 1859,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 1864,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.528,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1869,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.385,
+      "status": "SAT"
+    },
+    {
+      "id": 1874,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1879,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.704,
+      "status": "SAT"
+    },
+    {
+      "id": 1884,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.731,
+      "status": "SAT"
+    },
+    {
+      "id": 1889,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.579,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1894,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.741,
+      "status": "SAT"
+    },
+    {
+      "id": 1899,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1904,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 1909,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1914,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1919,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1924,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1929,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.494,
+      "status": "SAT"
+    },
+    {
+      "id": 1934,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.338,
+      "status": "SAT"
+    },
+    {
+      "id": 1939,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.557,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1944,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.422,
+      "status": "SAT"
+    },
+    {
+      "id": 1949,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1954,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.697,
+      "status": "SAT"
+    },
+    {
+      "id": 1959,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.725,
+      "status": "SAT"
+    },
+    {
+      "id": 1964,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.559,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1969,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.727,
+      "status": "SAT"
+    },
+    {
+      "id": 1974,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1979,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1984,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1989,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1994,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1999,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2004,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.409,
+      "status": "SAT"
+    },
+    {
+      "id": 2009,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.342,
+      "status": "SAT"
+    },
+    {
+      "id": 2014,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2019,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.429,
+      "status": "SAT"
+    },
+    {
+      "id": 2024,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.363,
+      "status": "SAT"
+    },
+    {
+      "id": 2029,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.749,
+      "status": "SAT"
+    },
+    {
+      "id": 2034,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 2039,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.045,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2044,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 3.209,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2049,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2054,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.129,
+      "status": "SAT"
+    },
+    {
+      "id": 2059,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 2064,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 2069,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2074,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.431,
+      "status": "SAT"
+    },
+    {
+      "id": 2079,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.541,
+      "status": "SAT"
+    },
+    {
+      "id": 2084,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2089,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.442,
+      "status": "SAT"
+    },
+    {
+      "id": 2094,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.612,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2099,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.723,
+      "status": "SAT"
+    },
+    {
+      "id": 2104,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.888,
+      "status": "SAT"
+    },
+    {
+      "id": 2109,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.157,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2114,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.715,
+      "status": "SAT"
+    },
+    {
+      "id": 2119,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2124,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.16,
+      "status": "SAT"
+    },
+    {
+      "id": 2129,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 2134,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2139,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.468,
+      "status": "SAT"
+    },
+    {
+      "id": 2144,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 2149,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2154,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 2159,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.584,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2164,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.774,
+      "status": "SAT"
+    },
+    {
+      "id": 2169,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.891,
+      "status": "SAT"
+    },
+    {
+      "id": 2174,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2179,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.86,
+      "status": "SAT"
+    },
+    {
+      "id": 2184,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2189,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 2194,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2199,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "SAT"
+    },
+    {
+      "id": 2204,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "SAT"
+    },
+    {
+      "id": 2209,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2214,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.586,
+      "status": "SAT"
+    },
+    {
+      "id": 2219,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.488,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2224,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.965,
+      "status": "SAT"
+    },
+    {
+      "id": 2229,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.905,
+      "status": "SAT"
+    },
+    {
+      "id": 2234,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2239,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.983,
+      "status": "SAT"
+    },
+    {
+      "id": 2244,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2249,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2254,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 2259,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "SAT"
+    },
+    {
+      "id": 2264,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.366,
+      "status": "SAT"
+    },
+    {
+      "id": 2269,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.521,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2274,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2279,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.985,
+      "status": "SAT"
+    },
+    {
+      "id": 2284,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.886,
+      "status": "SAT"
+    },
+    {
+      "id": 2289,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.509,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2294,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.981,
+      "status": "SAT"
+    },
+    {
+      "id": 2299,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.53,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2304,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.529,
+      "status": "SAT"
+    },
+    {
+      "id": 2309,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 2314,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.561,
+      "status": "SAT"
+    },
+    {
+      "id": 2319,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2324,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2329,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.902,
+      "status": "SAT"
+    },
+    {
+      "id": 2334,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.249,
+      "status": "SAT"
+    },
+    {
+      "id": 2339,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2344,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.928,
+      "status": "SAT"
+    },
+    {
+      "id": 2349,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2354,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.556,
+      "status": "SAT"
+    },
+    {
+      "id": 2359,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.263,
+      "status": "SAT"
+    },
+    {
+      "id": 2364,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.55,
+      "status": "SAT"
+    },
+    {
+      "id": 2369,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.27,
+      "status": "SAT"
+    },
+    {
+      "id": 2374,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2379,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.968,
+      "status": "SAT"
+    },
+    {
+      "id": 2384,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.282,
+      "status": "SAT"
+    },
+    {
+      "id": 2389,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2394,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.294,
+      "status": "SAT"
+    },
+    {
+      "id": 2399,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2404,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.3,
+      "status": "SAT"
+    },
+    {
+      "id": 2409,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.258,
+      "status": "SAT"
+    },
+    {
+      "id": 2414,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "SAT"
+    },
+    {
+      "id": 2419,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 2424,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2429,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 2434,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.277,
+      "status": "SAT"
+    },
+    {
+      "id": 2439,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2444,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.383,
+      "status": "SAT"
+    },
+    {
+      "id": 2449,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.529,
+      "status": "UNSAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_weak_left_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_weak_left_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 3,
+  "onnx_path": "networks/aprev_weak_left.onnx",
+  "mode": "discrete, EPS=0.0, timeout=60.0s per state",
+  "timestamp": "2026-04-14T20:26:16.222999",
+  "timeout_sec": 3600,
+  "total_wall_sec": 109.063,
+  "avg_sat_sec": 0.491,
+  "summary": {
+    "SAT": 316,
+    "UNSAT": 174,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 3,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.759,
+      "status": "SAT"
+    },
+    {
+      "id": 8,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.334,
+      "status": "SAT"
+    },
+    {
+      "id": 13,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 1.638,
+      "status": "UNSAT"
+    },
+    {
+      "id": 18,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 23,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 28,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.342,
+      "status": "SAT"
+    },
+    {
+      "id": 33,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.269,
+      "status": "SAT"
+    },
+    {
+      "id": 38,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 43,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.063,
+      "status": "UNSAT"
+    },
+    {
+      "id": 48,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.239,
+      "status": "SAT"
+    },
+    {
+      "id": 53,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 58,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 63,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 1.109,
+      "status": "UNSAT"
+    },
+    {
+      "id": 68,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.31,
+      "status": "SAT"
+    },
+    {
+      "id": 73,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 78,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.311,
+      "status": "SAT"
+    },
+    {
+      "id": 83,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.074,
+      "status": "UNSAT"
+    },
+    {
+      "id": 88,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 93,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.321,
+      "status": "SAT"
+    },
+    {
+      "id": 98,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.239,
+      "status": "SAT"
+    },
+    {
+      "id": 103,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 108,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 113,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.593,
+      "status": "UNSAT"
+    },
+    {
+      "id": 118,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.3,
+      "status": "SAT"
+    },
+    {
+      "id": 123,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 128,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.248,
+      "status": "SAT"
+    },
+    {
+      "id": 133,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.061,
+      "status": "UNSAT"
+    },
+    {
+      "id": 138,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 143,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.321,
+      "status": "SAT"
+    },
+    {
+      "id": 148,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.254,
+      "status": "SAT"
+    },
+    {
+      "id": 153,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 158,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "UNSAT"
+    },
+    {
+      "id": 163,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.306,
+      "status": "SAT"
+    },
+    {
+      "id": 168,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 173,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.269,
+      "status": "SAT"
+    },
+    {
+      "id": 178,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.665,
+      "status": "UNSAT"
+    },
+    {
+      "id": 183,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 188,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.355,
+      "status": "SAT"
+    },
+    {
+      "id": 193,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.254,
+      "status": "SAT"
+    },
+    {
+      "id": 198,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.257,
+      "status": "SAT"
+    },
+    {
+      "id": 203,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 208,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.294,
+      "status": "SAT"
+    },
+    {
+      "id": 213,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 218,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 223,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 3.258,
+      "status": "UNSAT"
+    },
+    {
+      "id": 228,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.602,
+      "status": "UNSAT"
+    },
+    {
+      "id": 233,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.399,
+      "status": "SAT"
+    },
+    {
+      "id": 238,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 243,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 248,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.263,
+      "status": "SAT"
+    },
+    {
+      "id": 253,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.279,
+      "status": "SAT"
+    },
+    {
+      "id": 258,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.292,
+      "status": "SAT"
+    },
+    {
+      "id": 263,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.569,
+      "status": "SAT"
+    },
+    {
+      "id": 268,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.953,
+      "status": "UNSAT"
+    },
+    {
+      "id": 273,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "UNSAT"
+    },
+    {
+      "id": 278,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 5.598,
+      "status": "UNSAT"
+    },
+    {
+      "id": 283,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.288,
+      "status": "SAT"
+    },
+    {
+      "id": 288,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 293,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 298,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 303,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 308,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 313,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.24,
+      "status": "SAT"
+    },
+    {
+      "id": 318,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.285,
+      "status": "SAT"
+    },
+    {
+      "id": 323,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 3.27,
+      "status": "UNSAT"
+    },
+    {
+      "id": 328,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.412,
+      "status": "SAT"
+    },
+    {
+      "id": 333,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 338,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.329,
+      "status": "SAT"
+    },
+    {
+      "id": 343,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 348,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.285,
+      "status": "SAT"
+    },
+    {
+      "id": 353,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 358,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.25,
+      "status": "SAT"
+    },
+    {
+      "id": 363,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.361,
+      "status": "SAT"
+    },
+    {
+      "id": 368,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.625,
+      "status": "UNSAT"
+    },
+    {
+      "id": 373,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.293,
+      "status": "SAT"
+    },
+    {
+      "id": 378,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 383,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.314,
+      "status": "SAT"
+    },
+    {
+      "id": 388,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.258,
+      "status": "SAT"
+    },
+    {
+      "id": 393,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 398,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 403,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 408,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.251,
+      "status": "SAT"
+    },
+    {
+      "id": 413,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.24,
+      "status": "SAT"
+    },
+    {
+      "id": 418,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.638,
+      "status": "UNSAT"
+    },
+    {
+      "id": 423,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.322,
+      "status": "SAT"
+    },
+    {
+      "id": 428,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.543,
+      "status": "UNSAT"
+    },
+    {
+      "id": 433,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.254,
+      "status": "SAT"
+    },
+    {
+      "id": 438,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 443,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 1.063,
+      "status": "UNSAT"
+    },
+    {
+      "id": 448,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.348,
+      "status": "SAT"
+    },
+    {
+      "id": 453,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "UNSAT"
+    },
+    {
+      "id": 458,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.253,
+      "status": "SAT"
+    },
+    {
+      "id": 463,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 468,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.132,
+      "status": "UNSAT"
+    },
+    {
+      "id": 473,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.302,
+      "status": "SAT"
+    },
+    {
+      "id": 478,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 483,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.58,
+      "status": "SAT"
+    },
+    {
+      "id": 488,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 493,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.312,
+      "status": "SAT"
+    },
+    {
+      "id": 498,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 503,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 5.355,
+      "status": "UNSAT"
+    },
+    {
+      "id": 508,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.921,
+      "status": "SAT"
+    },
+    {
+      "id": 513,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 518,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.685,
+      "status": "UNSAT"
+    },
+    {
+      "id": 523,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.306,
+      "status": "SAT"
+    },
+    {
+      "id": 528,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.276,
+      "status": "SAT"
+    },
+    {
+      "id": 533,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.524,
+      "status": "SAT"
+    },
+    {
+      "id": 538,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 543,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 1.468,
+      "status": "UNSAT"
+    },
+    {
+      "id": 548,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.261,
+      "status": "SAT"
+    },
+    {
+      "id": 553,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 3.329,
+      "status": "UNSAT"
+    },
+    {
+      "id": 558,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.885,
+      "status": "SAT"
+    },
+    {
+      "id": 563,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 568,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.092,
+      "status": "UNSAT"
+    },
+    {
+      "id": 573,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.347,
+      "status": "SAT"
+    },
+    {
+      "id": 578,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 1.66,
+      "status": "UNSAT"
+    },
+    {
+      "id": 583,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.521,
+      "status": "SAT"
+    },
+    {
+      "id": 588,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 593,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 598,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.296,
+      "status": "SAT"
+    },
+    {
+      "id": 603,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.909,
+      "status": "SAT"
+    },
+    {
+      "id": 608,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.877,
+      "status": "SAT"
+    },
+    {
+      "id": 613,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.261,
+      "status": "SAT"
+    },
+    {
+      "id": 618,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 623,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.332,
+      "status": "SAT"
+    },
+    {
+      "id": 628,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.534,
+      "status": "SAT"
+    },
+    {
+      "id": 633,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "SAT"
+    },
+    {
+      "id": 638,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.273,
+      "status": "SAT"
+    },
+    {
+      "id": 643,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 648,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.634,
+      "status": "SAT"
+    },
+    {
+      "id": 653,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.874,
+      "status": "SAT"
+    },
+    {
+      "id": 658,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.889,
+      "status": "SAT"
+    },
+    {
+      "id": 663,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.262,
+      "status": "SAT"
+    },
+    {
+      "id": 668,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 673,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.965,
+      "status": "SAT"
+    },
+    {
+      "id": 678,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.526,
+      "status": "SAT"
+    },
+    {
+      "id": 683,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 688,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 1.628,
+      "status": "UNSAT"
+    },
+    {
+      "id": 693,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 698,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.625,
+      "status": "SAT"
+    },
+    {
+      "id": 703,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 708,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.949,
+      "status": "SAT"
+    },
+    {
+      "id": 713,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.089,
+      "status": "UNSAT"
+    },
+    {
+      "id": 718,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.931,
+      "status": "SAT"
+    },
+    {
+      "id": 723,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 728,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.002,
+      "status": "SAT"
+    },
+    {
+      "id": 733,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.592,
+      "status": "SAT"
+    },
+    {
+      "id": 738,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.358,
+      "status": "SAT"
+    },
+    {
+      "id": 743,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.557,
+      "status": "SAT"
+    },
+    {
+      "id": 748,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 753,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.6,
+      "status": "SAT"
+    },
+    {
+      "id": 758,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 763,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 768,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.89,
+      "status": "SAT"
+    },
+    {
+      "id": 773,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.102,
+      "status": "UNSAT"
+    },
+    {
+      "id": 778,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.895,
+      "status": "SAT"
+    },
+    {
+      "id": 783,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 788,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.965,
+      "status": "SAT"
+    },
+    {
+      "id": 793,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 798,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.381,
+      "status": "SAT"
+    },
+    {
+      "id": 803,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 2.066,
+      "status": "UNSAT"
+    },
+    {
+      "id": 808,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 813,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "SAT"
+    },
+    {
+      "id": 818,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 823,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 828,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.128,
+      "status": "SAT"
+    },
+    {
+      "id": 833,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.538,
+      "status": "UNSAT"
+    },
+    {
+      "id": 838,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 843,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.909,
+      "status": "SAT"
+    },
+    {
+      "id": 848,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 853,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.979,
+      "status": "SAT"
+    },
+    {
+      "id": 858,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.36,
+      "status": "SAT"
+    },
+    {
+      "id": 863,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.389,
+      "status": "SAT"
+    },
+    {
+      "id": 868,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 2.017,
+      "status": "UNSAT"
+    },
+    {
+      "id": 873,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 878,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.385,
+      "status": "SAT"
+    },
+    {
+      "id": 883,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 888,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 893,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 898,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 903,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 3.079,
+      "status": "UNSAT"
+    },
+    {
+      "id": 908,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.111,
+      "status": "UNSAT"
+    },
+    {
+      "id": 913,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.89,
+      "status": "SAT"
+    },
+    {
+      "id": 918,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 923,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.724,
+      "status": "SAT"
+    },
+    {
+      "id": 928,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 933,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.37,
+      "status": "SAT"
+    },
+    {
+      "id": 938,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.372,
+      "status": "SAT"
+    },
+    {
+      "id": 943,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 948,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.464,
+      "status": "SAT"
+    },
+    {
+      "id": 953,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 958,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.129,
+      "status": "SAT"
+    },
+    {
+      "id": 963,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 968,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 973,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 978,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 983,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.58,
+      "status": "UNSAT"
+    },
+    {
+      "id": 988,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.717,
+      "status": "SAT"
+    },
+    {
+      "id": 993,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 998,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.73,
+      "status": "SAT"
+    },
+    {
+      "id": 1003,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.357,
+      "status": "SAT"
+    },
+    {
+      "id": 1008,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.347,
+      "status": "SAT"
+    },
+    {
+      "id": 1013,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.362,
+      "status": "SAT"
+    },
+    {
+      "id": 1018,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1023,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 1028,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1033,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.152,
+      "status": "SAT"
+    },
+    {
+      "id": 1038,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.119,
+      "status": "SAT"
+    },
+    {
+      "id": 1043,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1048,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1053,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.072,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1058,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 2.651,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1063,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.719,
+      "status": "SAT"
+    },
+    {
+      "id": 1068,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1073,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.692,
+      "status": "SAT"
+    },
+    {
+      "id": 1078,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1083,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 1088,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.348,
+      "status": "SAT"
+    },
+    {
+      "id": 1093,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.077,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1098,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.397,
+      "status": "SAT"
+    },
+    {
+      "id": 1103,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1108,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.282,
+      "status": "SAT"
+    },
+    {
+      "id": 1113,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1118,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1123,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1128,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1133,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.486,
+      "status": "SAT"
+    },
+    {
+      "id": 1138,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.738,
+      "status": "SAT"
+    },
+    {
+      "id": 1143,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.684,
+      "status": "SAT"
+    },
+    {
+      "id": 1148,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.711,
+      "status": "SAT"
+    },
+    {
+      "id": 1153,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1158,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1163,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.379,
+      "status": "SAT"
+    },
+    {
+      "id": 1168,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.544,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1173,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.394,
+      "status": "SAT"
+    },
+    {
+      "id": 1178,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1183,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.252,
+      "status": "SAT"
+    },
+    {
+      "id": 1188,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1193,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1198,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.129,
+      "status": "SAT"
+    },
+    {
+      "id": 1203,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1208,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.536,
+      "status": "SAT"
+    },
+    {
+      "id": 1213,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.727,
+      "status": "SAT"
+    },
+    {
+      "id": 1218,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.489,
+      "status": "SAT"
+    },
+    {
+      "id": 1223,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.718,
+      "status": "SAT"
+    },
+    {
+      "id": 1228,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1233,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1238,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.383,
+      "status": "SAT"
+    },
+    {
+      "id": 1243,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.496,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1248,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.419,
+      "status": "SAT"
+    },
+    {
+      "id": 1253,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1258,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 1263,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1268,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1273,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1278,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1283,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.499,
+      "status": "SAT"
+    },
+    {
+      "id": 1288,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.733,
+      "status": "SAT"
+    },
+    {
+      "id": 1293,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.039,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1298,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.747,
+      "status": "SAT"
+    },
+    {
+      "id": 1303,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1308,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.254,
+      "status": "SAT"
+    },
+    {
+      "id": 1313,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.366,
+      "status": "SAT"
+    },
+    {
+      "id": 1318,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1323,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1328,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1333,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1338,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1343,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1348,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.237,
+      "status": "SAT"
+    },
+    {
+      "id": 1353,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1358,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.433,
+      "status": "SAT"
+    },
+    {
+      "id": 1363,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.763,
+      "status": "SAT"
+    },
+    {
+      "id": 1368,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.027,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1373,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "SAT"
+    },
+    {
+      "id": 1378,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1383,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.245,
+      "status": "SAT"
+    },
+    {
+      "id": 1388,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1393,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1398,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1403,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1408,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.194,
+      "status": "SAT"
+    },
+    {
+      "id": 1413,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1418,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1423,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.247,
+      "status": "SAT"
+    },
+    {
+      "id": 1428,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1433,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.477,
+      "status": "SAT"
+    },
+    {
+      "id": 1438,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.451,
+      "status": "SAT"
+    },
+    {
+      "id": 1443,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.522,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1448,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 1453,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1458,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 1463,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1468,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1473,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.222,
+      "status": "SAT"
+    },
+    {
+      "id": 1478,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1483,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1488,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1493,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.514,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1498,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.218,
+      "status": "SAT"
+    },
+    {
+      "id": 1503,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1508,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1513,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.461,
+      "status": "SAT"
+    },
+    {
+      "id": 1518,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1523,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.592,
+      "status": "SAT"
+    },
+    {
+      "id": 1528,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1533,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1538,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1543,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1548,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.229,
+      "status": "SAT"
+    },
+    {
+      "id": 1553,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.509,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1558,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1563,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 1568,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1573,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1578,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.455,
+      "status": "SAT"
+    },
+    {
+      "id": 1583,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.028,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1588,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.435,
+      "status": "SAT"
+    },
+    {
+      "id": 1593,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1598,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "SAT"
+    },
+    {
+      "id": 1603,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 1608,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 1613,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1618,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1623,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.214,
+      "status": "SAT"
+    },
+    {
+      "id": 1628,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1633,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1638,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.517,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1643,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.24,
+      "status": "SAT"
+    },
+    {
+      "id": 1648,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1653,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.455,
+      "status": "SAT"
+    },
+    {
+      "id": 1658,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.06,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1663,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.419,
+      "status": "SAT"
+    },
+    {
+      "id": 1668,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1673,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.531,
+      "status": "SAT"
+    },
+    {
+      "id": 1678,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 1683,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.101,
+      "status": "SAT"
+    },
+    {
+      "id": 1688,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1693,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1698,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.216,
+      "status": "SAT"
+    },
+    {
+      "id": 1703,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1708,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1713,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.505,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1718,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.423,
+      "status": "SAT"
+    },
+    {
+      "id": 1723,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.208,
+      "status": "SAT"
+    },
+    {
+      "id": 1728,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.482,
+      "status": "SAT"
+    },
+    {
+      "id": 1733,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.002,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1738,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.466,
+      "status": "SAT"
+    },
+    {
+      "id": 1743,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1748,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.577,
+      "status": "SAT"
+    },
+    {
+      "id": 1753,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1758,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.083,
+      "status": "SAT"
+    },
+    {
+      "id": 1763,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1768,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1773,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.218,
+      "status": "SAT"
+    },
+    {
+      "id": 1778,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.368,
+      "status": "SAT"
+    },
+    {
+      "id": 1783,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.393,
+      "status": "SAT"
+    },
+    {
+      "id": 1788,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.513,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1793,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1798,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1803,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.792,
+      "status": "SAT"
+    },
+    {
+      "id": 1808,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.469,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1813,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.458,
+      "status": "SAT"
+    },
+    {
+      "id": 1818,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1823,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "SAT"
+    },
+    {
+      "id": 1828,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.1,
+      "status": "SAT"
+    },
+    {
+      "id": 1833,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1838,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.24,
+      "status": "SAT"
+    },
+    {
+      "id": 1843,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1848,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1853,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1858,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.393,
+      "status": "SAT"
+    },
+    {
+      "id": 1863,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.53,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1868,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.382,
+      "status": "SAT"
+    },
+    {
+      "id": 1873,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.365,
+      "status": "SAT"
+    },
+    {
+      "id": 1878,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.977,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1883,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1888,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.467,
+      "status": "SAT"
+    },
+    {
+      "id": 1893,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.502,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1898,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.845,
+      "status": "SAT"
+    },
+    {
+      "id": 1903,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1908,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1913,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 1918,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1923,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 1928,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.397,
+      "status": "SAT"
+    },
+    {
+      "id": 1933,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.353,
+      "status": "SAT"
+    },
+    {
+      "id": 1938,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1943,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.426,
+      "status": "SAT"
+    },
+    {
+      "id": 1948,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 1953,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.7,
+      "status": "SAT"
+    },
+    {
+      "id": 1958,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1963,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.057,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1968,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.485,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1973,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.798,
+      "status": "SAT"
+    },
+    {
+      "id": 1978,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.094,
+      "status": "SAT"
+    },
+    {
+      "id": 1983,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1988,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.088,
+      "status": "SAT"
+    },
+    {
+      "id": 1993,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1998,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 2003,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.379,
+      "status": "SAT"
+    },
+    {
+      "id": 2008,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.34,
+      "status": "SAT"
+    },
+    {
+      "id": 2013,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2018,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.463,
+      "status": "SAT"
+    },
+    {
+      "id": 2023,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.381,
+      "status": "SAT"
+    },
+    {
+      "id": 2028,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.738,
+      "status": "SAT"
+    },
+    {
+      "id": 2033,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.518,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2038,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.039,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2043,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2048,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.761,
+      "status": "SAT"
+    },
+    {
+      "id": 2053,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 2058,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2063,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2068,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 2073,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.358,
+      "status": "SAT"
+    },
+    {
+      "id": 2078,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.558,
+      "status": "SAT"
+    },
+    {
+      "id": 2083,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2088,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.411,
+      "status": "SAT"
+    },
+    {
+      "id": 2093,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.366,
+      "status": "SAT"
+    },
+    {
+      "id": 2098,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 2103,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2108,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.007,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2113,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2118,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.744,
+      "status": "SAT"
+    },
+    {
+      "id": 2123,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.122,
+      "status": "SAT"
+    },
+    {
+      "id": 2128,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 2133,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.117,
+      "status": "SAT"
+    },
+    {
+      "id": 2138,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.37,
+      "status": "SAT"
+    },
+    {
+      "id": 2143,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "SAT"
+    },
+    {
+      "id": 2148,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2153,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "SAT"
+    },
+    {
+      "id": 2158,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.373,
+      "status": "SAT"
+    },
+    {
+      "id": 2163,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.719,
+      "status": "SAT"
+    },
+    {
+      "id": 2168,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2173,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.095,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2178,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 3.166,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2183,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.813,
+      "status": "SAT"
+    },
+    {
+      "id": 2188,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 2193,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.099,
+      "status": "SAT"
+    },
+    {
+      "id": 2198,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 2203,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.548,
+      "status": "SAT"
+    },
+    {
+      "id": 2208,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2213,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.615,
+      "status": "SAT"
+    },
+    {
+      "id": 2218,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.385,
+      "status": "SAT"
+    },
+    {
+      "id": 2223,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.872,
+      "status": "SAT"
+    },
+    {
+      "id": 2228,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2233,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.039,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2238,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.62,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2243,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.71,
+      "status": "SAT"
+    },
+    {
+      "id": 2248,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.082,
+      "status": "SAT"
+    },
+    {
+      "id": 2253,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "SAT"
+    },
+    {
+      "id": 2258,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "SAT"
+    },
+    {
+      "id": 2263,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2268,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.582,
+      "status": "SAT"
+    },
+    {
+      "id": 2273,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "SAT"
+    },
+    {
+      "id": 2278,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.612,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2283,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2288,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.109,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2293,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.969,
+      "status": "SAT"
+    },
+    {
+      "id": 2298,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.864,
+      "status": "SAT"
+    },
+    {
+      "id": 2303,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.536,
+      "status": "SAT"
+    },
+    {
+      "id": 2308,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 2313,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2318,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.636,
+      "status": "SAT"
+    },
+    {
+      "id": 2323,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.536,
+      "status": "SAT"
+    },
+    {
+      "id": 2328,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.913,
+      "status": "SAT"
+    },
+    {
+      "id": 2333,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.58,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2338,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2343,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2348,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.888,
+      "status": "SAT"
+    },
+    {
+      "id": 2353,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 2358,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 2363,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2368,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.309,
+      "status": "SAT"
+    },
+    {
+      "id": 2373,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.547,
+      "status": "SAT"
+    },
+    {
+      "id": 2378,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2383,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.241,
+      "status": "SAT"
+    },
+    {
+      "id": 2388,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.526,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2393,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.508,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2398,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.887,
+      "status": "SAT"
+    },
+    {
+      "id": 2403,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.299,
+      "status": "SAT"
+    },
+    {
+      "id": 2408,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.261,
+      "status": "SAT"
+    },
+    {
+      "id": 2413,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2418,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.3,
+      "status": "SAT"
+    },
+    {
+      "id": 2423,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "SAT"
+    },
+    {
+      "id": 2428,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2433,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.267,
+      "status": "SAT"
+    },
+    {
+      "id": 2438,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2443,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.375,
+      "status": "SAT"
+    },
+    {
+      "id": 2448,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.9,
+      "status": "SAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_weak_right_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/discrete_goals/aprev_weak_right_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 2,
+  "onnx_path": "networks/aprev_weak_right.onnx",
+  "mode": "discrete, EPS=0.0, timeout=60.0s per state",
+  "timestamp": "2026-04-14T20:24:26.832688",
+  "timeout_sec": 3600,
+  "total_wall_sec": 39.319,
+  "avg_sat_sec": 0.557,
+  "summary": {
+    "SAT": 355,
+    "UNSAT": 135,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 2,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.792,
+      "status": "SAT"
+    },
+    {
+      "id": 7,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.282,
+      "status": "SAT"
+    },
+    {
+      "id": 12,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.58,
+      "status": "SAT"
+    },
+    {
+      "id": 17,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.299,
+      "status": "SAT"
+    },
+    {
+      "id": 22,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.361,
+      "status": "UNSAT"
+    },
+    {
+      "id": 27,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.397,
+      "status": "SAT"
+    },
+    {
+      "id": 32,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.366,
+      "status": "SAT"
+    },
+    {
+      "id": 37,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.905,
+      "status": "SAT"
+    },
+    {
+      "id": 42,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.26,
+      "status": "SAT"
+    },
+    {
+      "id": 47,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 52,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.332,
+      "status": "SAT"
+    },
+    {
+      "id": 57,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.322,
+      "status": "SAT"
+    },
+    {
+      "id": 62,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 67,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 72,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 77,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.301,
+      "status": "SAT"
+    },
+    {
+      "id": 82,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.272,
+      "status": "SAT"
+    },
+    {
+      "id": 87,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.342,
+      "status": "SAT"
+    },
+    {
+      "id": 92,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.241,
+      "status": "SAT"
+    },
+    {
+      "id": 97,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 102,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.328,
+      "status": "SAT"
+    },
+    {
+      "id": 107,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 112,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.293,
+      "status": "SAT"
+    },
+    {
+      "id": 117,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 122,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 127,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.358,
+      "status": "SAT"
+    },
+    {
+      "id": 132,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.318,
+      "status": "SAT"
+    },
+    {
+      "id": 137,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.335,
+      "status": "SAT"
+    },
+    {
+      "id": 142,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.285,
+      "status": "SAT"
+    },
+    {
+      "id": 147,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 152,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.363,
+      "status": "SAT"
+    },
+    {
+      "id": 157,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.277,
+      "status": "SAT"
+    },
+    {
+      "id": 162,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 167,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 172,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.363,
+      "status": "SAT"
+    },
+    {
+      "id": 177,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.451,
+      "status": "SAT"
+    },
+    {
+      "id": 182,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.329,
+      "status": "SAT"
+    },
+    {
+      "id": 187,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.281,
+      "status": "SAT"
+    },
+    {
+      "id": 192,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 197,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.325,
+      "status": "SAT"
+    },
+    {
+      "id": 202,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.273,
+      "status": "SAT"
+    },
+    {
+      "id": 207,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.26,
+      "status": "SAT"
+    },
+    {
+      "id": 212,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 217,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.326,
+      "status": "SAT"
+    },
+    {
+      "id": 222,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.275,
+      "status": "SAT"
+    },
+    {
+      "id": 227,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.294,
+      "status": "SAT"
+    },
+    {
+      "id": 232,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.392,
+      "status": "SAT"
+    },
+    {
+      "id": 237,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 242,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.339,
+      "status": "SAT"
+    },
+    {
+      "id": 247,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.301,
+      "status": "SAT"
+    },
+    {
+      "id": 252,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 257,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 262,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.372,
+      "status": "SAT"
+    },
+    {
+      "id": 267,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.236,
+      "status": "SAT"
+    },
+    {
+      "id": 272,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.315,
+      "status": "SAT"
+    },
+    {
+      "id": 277,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.33,
+      "status": "SAT"
+    },
+    {
+      "id": 282,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 287,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 292,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.317,
+      "status": "SAT"
+    },
+    {
+      "id": 297,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.279,
+      "status": "SAT"
+    },
+    {
+      "id": 302,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.289,
+      "status": "SAT"
+    },
+    {
+      "id": 307,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.336,
+      "status": "SAT"
+    },
+    {
+      "id": 312,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.283,
+      "status": "SAT"
+    },
+    {
+      "id": 317,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.32,
+      "status": "SAT"
+    },
+    {
+      "id": 322,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.323,
+      "status": "SAT"
+    },
+    {
+      "id": 327,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 332,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.347,
+      "status": "SAT"
+    },
+    {
+      "id": 337,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.311,
+      "status": "SAT"
+    },
+    {
+      "id": 342,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.285,
+      "status": "SAT"
+    },
+    {
+      "id": 347,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 352,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.36,
+      "status": "SAT"
+    },
+    {
+      "id": 357,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.321,
+      "status": "SAT"
+    },
+    {
+      "id": 362,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 1.384,
+      "status": "SAT"
+    },
+    {
+      "id": 367,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.281,
+      "status": "SAT"
+    },
+    {
+      "id": 372,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 377,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.328,
+      "status": "SAT"
+    },
+    {
+      "id": 382,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 387,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.273,
+      "status": "SAT"
+    },
+    {
+      "id": 392,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.295,
+      "status": "SAT"
+    },
+    {
+      "id": 397,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 402,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.377,
+      "status": "SAT"
+    },
+    {
+      "id": 407,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.298,
+      "status": "SAT"
+    },
+    {
+      "id": 412,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.245,
+      "status": "SAT"
+    },
+    {
+      "id": 417,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.264,
+      "status": "SAT"
+    },
+    {
+      "id": 422,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 427,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.303,
+      "status": "SAT"
+    },
+    {
+      "id": 432,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.299,
+      "status": "SAT"
+    },
+    {
+      "id": 437,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 442,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.28,
+      "status": "SAT"
+    },
+    {
+      "id": 447,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 452,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.552,
+      "status": "SAT"
+    },
+    {
+      "id": 457,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.688,
+      "status": "SAT"
+    },
+    {
+      "id": 462,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.571,
+      "status": "SAT"
+    },
+    {
+      "id": 467,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.435,
+      "status": "SAT"
+    },
+    {
+      "id": 472,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 477,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 482,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "SAT"
+    },
+    {
+      "id": 487,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.272,
+      "status": "SAT"
+    },
+    {
+      "id": 492,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.29,
+      "status": "SAT"
+    },
+    {
+      "id": 497,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 502,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.314,
+      "status": "SAT"
+    },
+    {
+      "id": 507,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.895,
+      "status": "SAT"
+    },
+    {
+      "id": 512,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.278,
+      "status": "SAT"
+    },
+    {
+      "id": 517,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.248,
+      "status": "SAT"
+    },
+    {
+      "id": 522,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 527,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.324,
+      "status": "SAT"
+    },
+    {
+      "id": 532,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.516,
+      "status": "SAT"
+    },
+    {
+      "id": 537,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.253,
+      "status": "SAT"
+    },
+    {
+      "id": 542,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.56,
+      "status": "SAT"
+    },
+    {
+      "id": 547,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 552,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.3,
+      "status": "SAT"
+    },
+    {
+      "id": 557,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.968,
+      "status": "SAT"
+    },
+    {
+      "id": 562,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.279,
+      "status": "SAT"
+    },
+    {
+      "id": 567,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.906,
+      "status": "SAT"
+    },
+    {
+      "id": 572,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 577,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.572,
+      "status": "SAT"
+    },
+    {
+      "id": 582,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.548,
+      "status": "SAT"
+    },
+    {
+      "id": 587,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.257,
+      "status": "SAT"
+    },
+    {
+      "id": 592,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.557,
+      "status": "SAT"
+    },
+    {
+      "id": 597,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 602,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.951,
+      "status": "SAT"
+    },
+    {
+      "id": 607,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.89,
+      "status": "SAT"
+    },
+    {
+      "id": 612,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.386,
+      "status": "SAT"
+    },
+    {
+      "id": 617,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.922,
+      "status": "SAT"
+    },
+    {
+      "id": 622,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 627,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.641,
+      "status": "SAT"
+    },
+    {
+      "id": 632,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.572,
+      "status": "SAT"
+    },
+    {
+      "id": 637,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.255,
+      "status": "SAT"
+    },
+    {
+      "id": 642,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.585,
+      "status": "SAT"
+    },
+    {
+      "id": 647,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 652,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.015,
+      "status": "SAT"
+    },
+    {
+      "id": 657,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.962,
+      "status": "SAT"
+    },
+    {
+      "id": 662,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.346,
+      "status": "SAT"
+    },
+    {
+      "id": 667,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.963,
+      "status": "SAT"
+    },
+    {
+      "id": 672,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 677,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "SAT"
+    },
+    {
+      "id": 682,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.364,
+      "status": "SAT"
+    },
+    {
+      "id": 687,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.512,
+      "status": "SAT"
+    },
+    {
+      "id": 692,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "SAT"
+    },
+    {
+      "id": 697,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 702,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.128,
+      "status": "SAT"
+    },
+    {
+      "id": 707,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.881,
+      "status": "SAT"
+    },
+    {
+      "id": 712,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.748,
+      "status": "SAT"
+    },
+    {
+      "id": 717,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.922,
+      "status": "SAT"
+    },
+    {
+      "id": 722,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.873,
+      "status": "SAT"
+    },
+    {
+      "id": 727,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 732,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.568,
+      "status": "SAT"
+    },
+    {
+      "id": 737,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.359,
+      "status": "SAT"
+    },
+    {
+      "id": 742,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.597,
+      "status": "SAT"
+    },
+    {
+      "id": 747,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.338,
+      "status": "SAT"
+    },
+    {
+      "id": 752,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 757,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 762,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 767,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.897,
+      "status": "SAT"
+    },
+    {
+      "id": 772,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.675,
+      "status": "SAT"
+    },
+    {
+      "id": 777,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.86,
+      "status": "SAT"
+    },
+    {
+      "id": 782,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.719,
+      "status": "SAT"
+    },
+    {
+      "id": 787,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 792,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.463,
+      "status": "SAT"
+    },
+    {
+      "id": 797,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.383,
+      "status": "SAT"
+    },
+    {
+      "id": 802,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.677,
+      "status": "SAT"
+    },
+    {
+      "id": 807,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.401,
+      "status": "SAT"
+    },
+    {
+      "id": 812,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 817,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 822,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.127,
+      "status": "SAT"
+    },
+    {
+      "id": 827,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.101,
+      "status": "SAT"
+    },
+    {
+      "id": 832,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.848,
+      "status": "SAT"
+    },
+    {
+      "id": 837,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.89,
+      "status": "SAT"
+    },
+    {
+      "id": 842,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.044,
+      "status": "SAT"
+    },
+    {
+      "id": 847,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.834,
+      "status": "SAT"
+    },
+    {
+      "id": 852,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 857,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.411,
+      "status": "SAT"
+    },
+    {
+      "id": 862,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 867,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "SAT"
+    },
+    {
+      "id": 872,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.356,
+      "status": "SAT"
+    },
+    {
+      "id": 877,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 882,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 887,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 892,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.091,
+      "status": "SAT"
+    },
+    {
+      "id": 897,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.021,
+      "status": "UNSAT"
+    },
+    {
+      "id": 902,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.779,
+      "status": "SAT"
+    },
+    {
+      "id": 907,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 912,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.897,
+      "status": "SAT"
+    },
+    {
+      "id": 917,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.756,
+      "status": "SAT"
+    },
+    {
+      "id": 922,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 927,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.394,
+      "status": "SAT"
+    },
+    {
+      "id": 932,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.389,
+      "status": "SAT"
+    },
+    {
+      "id": 937,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 942,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.353,
+      "status": "SAT"
+    },
+    {
+      "id": 947,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 952,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 957,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 962,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 967,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.083,
+      "status": "SAT"
+    },
+    {
+      "id": 972,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 977,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.746,
+      "status": "SAT"
+    },
+    {
+      "id": 982,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.743,
+      "status": "SAT"
+    },
+    {
+      "id": 987,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.716,
+      "status": "SAT"
+    },
+    {
+      "id": 992,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 997,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1002,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.427,
+      "status": "SAT"
+    },
+    {
+      "id": 1007,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.344,
+      "status": "SAT"
+    },
+    {
+      "id": 1012,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.341,
+      "status": "SAT"
+    },
+    {
+      "id": 1017,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.371,
+      "status": "SAT"
+    },
+    {
+      "id": 1022,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1027,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.126,
+      "status": "SAT"
+    },
+    {
+      "id": 1032,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.107,
+      "status": "SAT"
+    },
+    {
+      "id": 1037,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1042,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.1,
+      "status": "SAT"
+    },
+    {
+      "id": 1047,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1052,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.885,
+      "status": "SAT"
+    },
+    {
+      "id": 1057,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.869,
+      "status": "SAT"
+    },
+    {
+      "id": 1062,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.799,
+      "status": "SAT"
+    },
+    {
+      "id": 1067,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.791,
+      "status": "SAT"
+    },
+    {
+      "id": 1072,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1077,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.441,
+      "status": "SAT"
+    },
+    {
+      "id": 1082,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.194,
+      "status": "SAT"
+    },
+    {
+      "id": 1087,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.42,
+      "status": "SAT"
+    },
+    {
+      "id": 1092,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.353,
+      "status": "SAT"
+    },
+    {
+      "id": 1097,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1102,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 1107,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.255,
+      "status": "SAT"
+    },
+    {
+      "id": 1112,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "SAT"
+    },
+    {
+      "id": 1117,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.103,
+      "status": "SAT"
+    },
+    {
+      "id": 1122,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1127,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.831,
+      "status": "SAT"
+    },
+    {
+      "id": 1132,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.572,
+      "status": "SAT"
+    },
+    {
+      "id": 1137,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.889,
+      "status": "SAT"
+    },
+    {
+      "id": 1142,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.801,
+      "status": "SAT"
+    },
+    {
+      "id": 1147,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1152,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.512,
+      "status": "SAT"
+    },
+    {
+      "id": 1157,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.233,
+      "status": "SAT"
+    },
+    {
+      "id": 1162,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.463,
+      "status": "SAT"
+    },
+    {
+      "id": 1167,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.236,
+      "status": "SAT"
+    },
+    {
+      "id": 1172,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1177,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1182,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 1187,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1192,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1197,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 1202,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.768,
+      "status": "SAT"
+    },
+    {
+      "id": 1207,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.538,
+      "status": "SAT"
+    },
+    {
+      "id": 1212,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.82,
+      "status": "SAT"
+    },
+    {
+      "id": 1217,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.171,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1222,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1227,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.242,
+      "status": "SAT"
+    },
+    {
+      "id": 1232,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.22,
+      "status": "SAT"
+    },
+    {
+      "id": 1237,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.368,
+      "status": "SAT"
+    },
+    {
+      "id": 1242,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.237,
+      "status": "SAT"
+    },
+    {
+      "id": 1247,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1252,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.546,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1257,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.259,
+      "status": "SAT"
+    },
+    {
+      "id": 1262,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1267,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1272,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 1277,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.593,
+      "status": "SAT"
+    },
+    {
+      "id": 1282,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.523,
+      "status": "SAT"
+    },
+    {
+      "id": 1287,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.857,
+      "status": "SAT"
+    },
+    {
+      "id": 1292,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1297,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1302,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.256,
+      "status": "SAT"
+    },
+    {
+      "id": 1307,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.222,
+      "status": "SAT"
+    },
+    {
+      "id": 1312,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.457,
+      "status": "SAT"
+    },
+    {
+      "id": 1317,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.236,
+      "status": "SAT"
+    },
+    {
+      "id": 1322,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1327,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.247,
+      "status": "SAT"
+    },
+    {
+      "id": 1332,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.197,
+      "status": "SAT"
+    },
+    {
+      "id": 1337,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.126,
+      "status": "SAT"
+    },
+    {
+      "id": 1342,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1347,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.562,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1352,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.597,
+      "status": "SAT"
+    },
+    {
+      "id": 1357,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.555,
+      "status": "SAT"
+    },
+    {
+      "id": 1362,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.856,
+      "status": "SAT"
+    },
+    {
+      "id": 1367,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1372,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1377,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.265,
+      "status": "SAT"
+    },
+    {
+      "id": 1382,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.208,
+      "status": "SAT"
+    },
+    {
+      "id": 1387,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.235,
+      "status": "SAT"
+    },
+    {
+      "id": 1392,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 1397,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1402,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.243,
+      "status": "SAT"
+    },
+    {
+      "id": 1407,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.225,
+      "status": "SAT"
+    },
+    {
+      "id": 1412,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 1417,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1422,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1427,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.696,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1432,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.648,
+      "status": "SAT"
+    },
+    {
+      "id": 1437,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "SAT"
+    },
+    {
+      "id": 1442,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.019,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1447,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1452,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1457,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.209,
+      "status": "SAT"
+    },
+    {
+      "id": 1462,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1467,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.228,
+      "status": "SAT"
+    },
+    {
+      "id": 1472,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1477,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.247,
+      "status": "SAT"
+    },
+    {
+      "id": 1482,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1487,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.211,
+      "status": "SAT"
+    },
+    {
+      "id": 1492,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1497,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.526,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1502,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1507,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.504,
+      "status": "SAT"
+    },
+    {
+      "id": 1512,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.495,
+      "status": "SAT"
+    },
+    {
+      "id": 1517,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.123,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1522,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1527,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.23,
+      "status": "SAT"
+    },
+    {
+      "id": 1532,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.238,
+      "status": "SAT"
+    },
+    {
+      "id": 1537,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1542,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.264,
+      "status": "SAT"
+    },
+    {
+      "id": 1547,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1552,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.31,
+      "status": "SAT"
+    },
+    {
+      "id": 1557,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.222,
+      "status": "SAT"
+    },
+    {
+      "id": 1562,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.247,
+      "status": "SAT"
+    },
+    {
+      "id": 1567,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1572,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.584,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1577,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.525,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1582,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.553,
+      "status": "SAT"
+    },
+    {
+      "id": 1587,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.453,
+      "status": "SAT"
+    },
+    {
+      "id": 1592,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.059,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1597,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1602,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1607,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.095,
+      "status": "SAT"
+    },
+    {
+      "id": 1612,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.192,
+      "status": "SAT"
+    },
+    {
+      "id": 1617,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.199,
+      "status": "SAT"
+    },
+    {
+      "id": 1622,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1627,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.244,
+      "status": "SAT"
+    },
+    {
+      "id": 1632,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.393,
+      "status": "SAT"
+    },
+    {
+      "id": 1637,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1642,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1647,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.516,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1652,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1657,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.754,
+      "status": "SAT"
+    },
+    {
+      "id": 1662,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.463,
+      "status": "SAT"
+    },
+    {
+      "id": 1667,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.042,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1672,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.548,
+      "status": "SAT"
+    },
+    {
+      "id": 1677,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 1682,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.089,
+      "status": "SAT"
+    },
+    {
+      "id": 1687,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 1692,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.106,
+      "status": "SAT"
+    },
+    {
+      "id": 1697,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1702,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.23,
+      "status": "SAT"
+    },
+    {
+      "id": 1707,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.376,
+      "status": "SAT"
+    },
+    {
+      "id": 1712,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1717,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1722,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1727,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.524,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1732,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.814,
+      "status": "SAT"
+    },
+    {
+      "id": 1737,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.508,
+      "status": "SAT"
+    },
+    {
+      "id": 1742,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.079,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1747,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1752,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 1757,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.096,
+      "status": "SAT"
+    },
+    {
+      "id": 1762,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1767,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.097,
+      "status": "SAT"
+    },
+    {
+      "id": 1772,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1777,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.485,
+      "status": "SAT"
+    },
+    {
+      "id": 1782,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1787,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 1792,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.422,
+      "status": "SAT"
+    },
+    {
+      "id": 1797,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.572,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1802,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.544,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1807,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.042,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1812,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.465,
+      "status": "SAT"
+    },
+    {
+      "id": 1817,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.581,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1822,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1827,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1832,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1837,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 1842,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.098,
+      "status": "SAT"
+    },
+    {
+      "id": 1847,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 1852,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.377,
+      "status": "SAT"
+    },
+    {
+      "id": 1857,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.021,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1862,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.198,
+      "status": "SAT"
+    },
+    {
+      "id": 1867,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1872,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.504,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1877,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1882,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.558,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1887,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.485,
+      "status": "SAT"
+    },
+    {
+      "id": 1892,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.031,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1897,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.725,
+      "status": "SAT"
+    },
+    {
+      "id": 1902,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1907,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.127,
+      "status": "SAT"
+    },
+    {
+      "id": 1912,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 1917,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 1922,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.086,
+      "status": "SAT"
+    },
+    {
+      "id": 1927,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.364,
+      "status": "SAT"
+    },
+    {
+      "id": 1932,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.36,
+      "status": "SAT"
+    },
+    {
+      "id": 1937,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.362,
+      "status": "SAT"
+    },
+    {
+      "id": 1942,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.374,
+      "status": "SAT"
+    },
+    {
+      "id": 1947,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1952,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1957,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1962,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.75,
+      "status": "SAT"
+    },
+    {
+      "id": 1967,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.709,
+      "status": "SAT"
+    },
+    {
+      "id": 1972,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.016,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1977,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1982,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.146,
+      "status": "SAT"
+    },
+    {
+      "id": 1987,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.096,
+      "status": "SAT"
+    },
+    {
+      "id": 1992,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.092,
+      "status": "SAT"
+    },
+    {
+      "id": 1997,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.113,
+      "status": "SAT"
+    },
+    {
+      "id": 2002,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.352,
+      "status": "SAT"
+    },
+    {
+      "id": 2007,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.362,
+      "status": "SAT"
+    },
+    {
+      "id": 2012,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.38,
+      "status": "SAT"
+    },
+    {
+      "id": 2017,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 2022,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2027,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2032,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2037,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.743,
+      "status": "SAT"
+    },
+    {
+      "id": 2042,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 3.341,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2047,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2052,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2057,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 2062,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.09,
+      "status": "SAT"
+    },
+    {
+      "id": 2067,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.093,
+      "status": "SAT"
+    },
+    {
+      "id": 2072,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.373,
+      "status": "SAT"
+    },
+    {
+      "id": 2077,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.546,
+      "status": "SAT"
+    },
+    {
+      "id": 2082,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.384,
+      "status": "SAT"
+    },
+    {
+      "id": 2087,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.351,
+      "status": "SAT"
+    },
+    {
+      "id": 2092,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2097,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2102,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2107,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.716,
+      "status": "SAT"
+    },
+    {
+      "id": 2112,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.734,
+      "status": "SAT"
+    },
+    {
+      "id": 2117,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.038,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2122,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 2127,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.113,
+      "status": "SAT"
+    },
+    {
+      "id": 2132,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.087,
+      "status": "SAT"
+    },
+    {
+      "id": 2137,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.375,
+      "status": "SAT"
+    },
+    {
+      "id": 2142,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "SAT"
+    },
+    {
+      "id": 2147,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.382,
+      "status": "SAT"
+    },
+    {
+      "id": 2152,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "SAT"
+    },
+    {
+      "id": 2157,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2162,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.776,
+      "status": "SAT"
+    },
+    {
+      "id": 2167,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2172,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.726,
+      "status": "SAT"
+    },
+    {
+      "id": 2177,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.884,
+      "status": "SAT"
+    },
+    {
+      "id": 2182,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.039,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2187,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2192,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.095,
+      "status": "SAT"
+    },
+    {
+      "id": 2197,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.544,
+      "status": "SAT"
+    },
+    {
+      "id": 2202,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.555,
+      "status": "SAT"
+    },
+    {
+      "id": 2207,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.365,
+      "status": "SAT"
+    },
+    {
+      "id": 2212,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.59,
+      "status": "SAT"
+    },
+    {
+      "id": 2217,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2222,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.978,
+      "status": "SAT"
+    },
+    {
+      "id": 2227,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2232,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.697,
+      "status": "SAT"
+    },
+    {
+      "id": 2237,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.908,
+      "status": "SAT"
+    },
+    {
+      "id": 2242,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.078,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2247,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 2252,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.52,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2257,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.54,
+      "status": "SAT"
+    },
+    {
+      "id": 2262,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.363,
+      "status": "SAT"
+    },
+    {
+      "id": 2267,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.536,
+      "status": "SAT"
+    },
+    {
+      "id": 2272,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2277,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.985,
+      "status": "SAT"
+    },
+    {
+      "id": 2282,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2287,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.713,
+      "status": "SAT"
+    },
+    {
+      "id": 2292,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.883,
+      "status": "SAT"
+    },
+    {
+      "id": 2297,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.539,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2302,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.578,
+      "status": "SAT"
+    },
+    {
+      "id": 2307,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.278,
+      "status": "SAT"
+    },
+    {
+      "id": 2312,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.523,
+      "status": "SAT"
+    },
+    {
+      "id": 2317,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 2322,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2327,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.933,
+      "status": "SAT"
+    },
+    {
+      "id": 2332,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.313,
+      "status": "SAT"
+    },
+    {
+      "id": 2337,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.931,
+      "status": "SAT"
+    },
+    {
+      "id": 2342,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.911,
+      "status": "SAT"
+    },
+    {
+      "id": 2347,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2352,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.638,
+      "status": "SAT"
+    },
+    {
+      "id": 2357,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.269,
+      "status": "SAT"
+    },
+    {
+      "id": 2362,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "SAT"
+    },
+    {
+      "id": 2367,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.273,
+      "status": "SAT"
+    },
+    {
+      "id": 2372,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2377,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.006,
+      "status": "SAT"
+    },
+    {
+      "id": 2382,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.274,
+      "status": "SAT"
+    },
+    {
+      "id": 2387,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.867,
+      "status": "SAT"
+    },
+    {
+      "id": 2392,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.274,
+      "status": "SAT"
+    },
+    {
+      "id": 2397,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2402,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.365,
+      "status": "SAT"
+    },
+    {
+      "id": 2407,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.323,
+      "status": "SAT"
+    },
+    {
+      "id": 2412,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.67,
+      "status": "SAT"
+    },
+    {
+      "id": 2417,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.339,
+      "status": "SAT"
+    },
+    {
+      "id": 2422,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2427,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.348,
+      "status": "SAT"
+    },
+    {
+      "id": 2432,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.261,
+      "status": "SAT"
+    },
+    {
+      "id": 2437,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.912,
+      "status": "SAT"
+    },
+    {
+      "id": 2442,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.281,
+      "status": "SAT"
+    },
+    {
+      "id": 2447,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/retry_all_discrete.sh
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/retry_all_discrete.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Retry TIMEOUT contracts from all 5 discrete NN results via PGD.
+# Uses temp YAML configs per NN since the parallel script reads network_idx/output_path from YAML.
+
+set -euo pipefail
+
+declare -A NN_MAP=(
+    [1]="aprev_clear"
+    [2]="aprev_weak_right"
+    [3]="aprev_weak_left"
+    [4]="aprev_strong_right"
+    [5]="aprev_strong_left"
+)
+
+BASE_CFG="verify_acas_contracts_config.yaml"
+OUT_DIR="contracts/discrete_goals"
+
+for IDX in 1 2 3 4 5; do
+    NAME="${NN_MAP[$IDX]}"
+    OUTPUT="${OUT_DIR}/${NAME}_crown_results.json"
+    TMP_CFG="verify_acas_contracts_config_nn${IDX}.yaml"
+
+    echo "========================================"
+    echo "Retry NN ${IDX}: ${NAME}"
+    echo "========================================"
+
+    # Create per-NN YAML by overriding network_idx and output_path
+    python3 -c "
+import yaml
+with open('${BASE_CFG}') as f: c = yaml.safe_load(f)
+c['network_idx'] = ${IDX}
+c['output_path'] = '${OUTPUT}'
+with open('${TMP_CFG}', 'w') as f: yaml.dump(c, f)
+"
+
+    python3 verify_acas_contracts_parallel.py \
+        --config      "${TMP_CFG}" \
+        --retry-from  "${OUTPUT}" \
+        --timeout     3600 \
+        --discrete \
+        --discrete-timeout 60 \
+        --device      cuda \
+        --workers     8
+
+    rm -f "${TMP_CFG}"
+    echo ""
+done
+
+echo "All NN retries complete."

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/verify_acas_contracts.py
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/verify_acas_contracts.py
@@ -23,6 +23,7 @@ Output: JSON report (path set in YAML)
 Run from:  REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/
 """
 
+import os
 import sys
 import json
 import functools
@@ -184,6 +185,7 @@ def save_report(
         "summary":         {**counts, "total": len(records)},
         "contracts":       records,
     }
+    os.makedirs(os.path.dirname(cfg["output_path"]) or ".", exist_ok=True)
     with open(cfg["output_path"], "w", encoding="utf-8") as f:
         json.dump(report, f, indent=2)
     print(f"Results saved to {cfg['output_path']}")


### PR DESCRIPTION
## Summary

Discrete-mode A/G contract verification results for all 5 ACAS Xu networks using alpha-beta-CROWN on an RTX 5090 (CUDA).

| NN | Network | SAT | UNSAT |
|----|---------|-----|-------|
| 1 | aprev_clear | 311 | 179 |
| 2 | aprev_weak_right | 355 | 135 |
| 3 | aprev_weak_left | 316 | 174 |
| 4 | aprev_strong_right | 335 | 155 |
| 5 | aprev_strong_left | 342 | 148 |
| **Total** | | **1659** | **791** |

0 TIMEOUT contracts across all 2450. PGD-first verification (falsify before satisfy) resolves every previously-TIMEOUT contract as UNSAT in seconds.

## Workflow

1. `verify_all_discrete_contracts.sh` (BaB, 5s per-state timeout) produced a first pass: 311-355 SAT and 135-179 TIMEOUT per NN.
2. New `retry_all_discrete.sh` loops all 5 NNs through `verify_acas_contracts_parallel.py` with `--device cuda` and `--discrete-timeout 60` — PGD attacks find counterexamples for every TIMEOUT.

## Changes

- **`contracts/discrete_goals/aprev_*_crown_results.json`** — 5 JSON files, final verdicts for all 490 contracts per NN.
- **`retry_all_discrete.sh`** — loops all 5 NNs, writes a temp per-NN YAML (network_idx + output_path), calls the parallel verifier with PGD enabled.
- **`verify_acas_contracts.py`** — `save_report()` now creates the output parent directory if missing. Previously, `contracts/discrete_goals/` had to be created manually or the run failed with `FileNotFoundError` at the end.

## Test plan

- [x] Ran all 5 NNs end-to-end; all 2450 contracts resolved (no TIMEOUTs remain).
- [ ] `./run_all_continuous_pipelines.sh contracts/discrete_goals/` to feed these verdicts into the compositional pipeline (not part of this PR).

## Notes

Continuous contract verification for NNs 2-5 is still running and will be submitted as a separate PR.