### PR TITLE
Add continuous ACAS Xu contract results (NNs 2-5) + Windows pipeline fixes

### DIFF
--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_strong_left_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_strong_left_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 5,
+  "onnx_path": "networks/aprev_strong_left.onnx",
+  "mode": "continuous",
+  "timestamp": "2026-04-15T17:00:40.193550",
+  "timeout_sec": 30,
+  "total_wall_sec": 5311.373,
+  "avg_sat_sec": 0.095,
+  "summary": {
+    "SAT": 314,
+    "UNSAT": 0,
+    "TIMEOUT": 176,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 5,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.07,
+      "status": "SAT"
+    },
+    {
+      "id": 10,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 15,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 20,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 25,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.055,
+      "status": "SAT"
+    },
+    {
+      "id": 30,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 35,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 40,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 45,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 50,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 55,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 60,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 65,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 70,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 75,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 80,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 85,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 90,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 95,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 100,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 105,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 110,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 115,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 120,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 125,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 130,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 135,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 140,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 145,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 150,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 155,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 160,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 165,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 170,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 175,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 180,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 185,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.164,
+      "status": "SAT"
+    },
+    {
+      "id": 190,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 195,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 200,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 205,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 210,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 215,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 220,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 225,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 230,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.197,
+      "status": "SAT"
+    },
+    {
+      "id": 235,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 240,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.198,
+      "status": "SAT"
+    },
+    {
+      "id": 245,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 250,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 255,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 260,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 265,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 270,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 275,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 280,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 285,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 290,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 295,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.045,
+      "status": "SAT"
+    },
+    {
+      "id": 300,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 305,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 310,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 315,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 320,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.161,
+      "status": "SAT"
+    },
+    {
+      "id": 325,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 330,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 335,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 340,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 345,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 350,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 355,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 360,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.159,
+      "status": "SAT"
+    },
+    {
+      "id": 365,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 370,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 375,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.159,
+      "status": "SAT"
+    },
+    {
+      "id": 380,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 385,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 390,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 395,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 400,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 405,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 410,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 415,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 420,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 425,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.167,
+      "status": "SAT"
+    },
+    {
+      "id": 430,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 435,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 440,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 445,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 450,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.056,
+      "status": "SAT"
+    },
+    {
+      "id": 455,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 460,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 465,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 470,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 475,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 480,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 485,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 490,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 495,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 500,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 505,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 510,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 515,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 520,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 525,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 530,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.052,
+      "status": "SAT"
+    },
+    {
+      "id": 535,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 540,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 545,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 550,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 555,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 560,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 565,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 570,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 575,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 580,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 585,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.145,
+      "status": "SAT"
+    },
+    {
+      "id": 590,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 595,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 600,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 605,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 610,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 615,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 620,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 625,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 630,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 635,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 640,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 645,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 650,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 655,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.019,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 660,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 665,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 670,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 675,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 680,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 685,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 690,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 695,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 700,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.054,
+      "status": "SAT"
+    },
+    {
+      "id": 705,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 710,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 715,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.019,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 720,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 725,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 730,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 735,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 740,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 745,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 750,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 755,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 760,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 765,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 770,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 775,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 780,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 785,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 790,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 795,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 800,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 805,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 810,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 815,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 820,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 825,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 830,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 835,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 840,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 845,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.238,
+      "status": "SAT"
+    },
+    {
+      "id": 850,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 855,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 860,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 865,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 870,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 875,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 880,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 885,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 890,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 895,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 900,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 905,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 910,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 915,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.267,
+      "status": "SAT"
+    },
+    {
+      "id": 920,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 925,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 930,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 935,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 940,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 945,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 950,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 955,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 960,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 965,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 970,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 975,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 980,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 985,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 990,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.246,
+      "status": "SAT"
+    },
+    {
+      "id": 995,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1000,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1005,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1010,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1015,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1020,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 1025,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1030,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1035,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1040,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1045,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1050,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1055,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1060,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1065,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.275,
+      "status": "SAT"
+    },
+    {
+      "id": 1070,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1075,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1080,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1085,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1090,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.252,
+      "status": "SAT"
+    },
+    {
+      "id": 1095,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1100,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1105,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1110,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1115,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1120,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1125,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1130,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1135,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1140,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 1145,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 1150,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.134,
+      "status": "SAT"
+    },
+    {
+      "id": 1155,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1160,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1165,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1170,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1175,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1180,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 1185,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1190,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1195,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1200,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1205,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1210,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1215,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.16,
+      "status": "SAT"
+    },
+    {
+      "id": 1220,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 1225,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.151,
+      "status": "SAT"
+    },
+    {
+      "id": 1230,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1235,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1240,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1245,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.324,
+      "status": "SAT"
+    },
+    {
+      "id": 1250,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1255,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1260,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1265,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1270,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1275,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1280,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1285,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.018,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1290,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 1295,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 1300,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1305,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1310,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1315,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1320,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1325,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1330,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1335,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1340,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1345,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1350,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1355,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1360,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1365,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.148,
+      "status": "SAT"
+    },
+    {
+      "id": 1370,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 1375,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1380,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1385,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1390,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1395,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1400,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1405,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.045,
+      "status": "SAT"
+    },
+    {
+      "id": 1410,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1415,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1420,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1425,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1430,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1435,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1440,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.161,
+      "status": "SAT"
+    },
+    {
+      "id": 1445,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 1450,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 1455,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1460,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1465,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1470,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1475,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1480,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1485,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1490,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1495,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1500,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1505,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1510,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1515,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1520,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1525,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 1530,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1535,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1540,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1545,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1550,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1555,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1560,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1565,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1570,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1575,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1580,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1585,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1590,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1595,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 1600,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.159,
+      "status": "SAT"
+    },
+    {
+      "id": 1605,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1610,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1615,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1620,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1625,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1630,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1635,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1640,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1645,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1650,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1655,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1660,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1665,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.146,
+      "status": "SAT"
+    },
+    {
+      "id": 1670,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.134,
+      "status": "SAT"
+    },
+    {
+      "id": 1675,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 1680,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1685,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1690,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1695,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1700,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1705,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1710,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1715,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1720,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1725,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1730,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1735,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1740,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.16,
+      "status": "SAT"
+    },
+    {
+      "id": 1745,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.148,
+      "status": "SAT"
+    },
+    {
+      "id": 1750,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.151,
+      "status": "SAT"
+    },
+    {
+      "id": 1755,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1760,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1765,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1770,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1775,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1780,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1785,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1790,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 1795,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 1800,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.145,
+      "status": "SAT"
+    },
+    {
+      "id": 1805,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1810,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1815,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1820,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 1825,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.146,
+      "status": "SAT"
+    },
+    {
+      "id": 1830,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1835,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1840,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1845,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1850,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.046,
+      "status": "SAT"
+    },
+    {
+      "id": 1855,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1860,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1865,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 1870,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.162,
+      "status": "SAT"
+    },
+    {
+      "id": 1875,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.134,
+      "status": "SAT"
+    },
+    {
+      "id": 1880,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1885,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1890,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.148,
+      "status": "SAT"
+    },
+    {
+      "id": 1895,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 1900,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 1905,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1910,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1915,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1920,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1925,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1930,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1935,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1940,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.047,
+      "status": "SAT"
+    },
+    {
+      "id": 1945,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1950,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1955,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1960,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1965,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 1970,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.216,
+      "status": "SAT"
+    },
+    {
+      "id": 1975,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.163,
+      "status": "SAT"
+    },
+    {
+      "id": 1980,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1985,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1990,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1995,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2000,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2005,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2010,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 2015,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2020,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.166,
+      "status": "SAT"
+    },
+    {
+      "id": 2025,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2030,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2035,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2040,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 2045,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 2050,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.158,
+      "status": "SAT"
+    },
+    {
+      "id": 2055,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2060,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2065,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2070,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2075,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2080,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2085,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 2090,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 2095,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 2100,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2105,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2110,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 2115,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 2120,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.152,
+      "status": "SAT"
+    },
+    {
+      "id": 2125,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 2130,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 2135,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 2140,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2145,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2150,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 2155,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 2160,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 2165,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2170,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2175,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 2180,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 2185,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 2190,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 2195,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2200,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2205,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2210,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.167,
+      "status": "SAT"
+    },
+    {
+      "id": 2215,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.243,
+      "status": "SAT"
+    },
+    {
+      "id": 2220,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 2225,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2230,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2235,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 2240,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.196,
+      "status": "SAT"
+    },
+    {
+      "id": 2245,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.207,
+      "status": "SAT"
+    },
+    {
+      "id": 2250,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 2255,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2260,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2265,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 2270,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.229,
+      "status": "SAT"
+    },
+    {
+      "id": 2275,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 2280,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2285,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2290,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.227,
+      "status": "SAT"
+    },
+    {
+      "id": 2295,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.27,
+      "status": "SAT"
+    },
+    {
+      "id": 2300,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 2305,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2310,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2315,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2320,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 2325,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 2330,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2335,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2340,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 2345,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2350,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 2355,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.018,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2360,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 2365,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.052,
+      "status": "SAT"
+    },
+    {
+      "id": 2370,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.053,
+      "status": "SAT"
+    },
+    {
+      "id": 2375,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.055,
+      "status": "SAT"
+    },
+    {
+      "id": 2380,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2385,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2390,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 2395,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2400,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 2405,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2410,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2415,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2420,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2425,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 2430,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2435,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2440,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 2445,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2450,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_strong_right_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_strong_right_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 4,
+  "onnx_path": "networks/aprev_strong_right.onnx",
+  "mode": "continuous",
+  "timestamp": "2026-04-15T15:32:05.003263",
+  "timeout_sec": 30,
+  "total_wall_sec": 5286.013,
+  "avg_sat_sec": 0.109,
+  "summary": {
+    "SAT": 315,
+    "UNSAT": 0,
+    "TIMEOUT": 175,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 4,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.084,
+      "status": "SAT"
+    },
+    {
+      "id": 9,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.047,
+      "status": "SAT"
+    },
+    {
+      "id": 14,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 19,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.055,
+      "status": "SAT"
+    },
+    {
+      "id": 24,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 29,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 34,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 39,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 44,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.21,
+      "status": "SAT"
+    },
+    {
+      "id": 49,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 54,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 59,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 64,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 69,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 74,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 79,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.2,
+      "status": "SAT"
+    },
+    {
+      "id": 84,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 89,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 94,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 99,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 104,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 109,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 114,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 119,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 124,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 129,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.166,
+      "status": "SAT"
+    },
+    {
+      "id": 134,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 139,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 144,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.165,
+      "status": "SAT"
+    },
+    {
+      "id": 149,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 154,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 159,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 164,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 169,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 174,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.179,
+      "status": "SAT"
+    },
+    {
+      "id": 179,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 184,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 189,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 194,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 199,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 204,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 209,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 214,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 219,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 224,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 229,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 234,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.167,
+      "status": "SAT"
+    },
+    {
+      "id": 239,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 244,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 249,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 254,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 259,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 264,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.217,
+      "status": "SAT"
+    },
+    {
+      "id": 269,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.166,
+      "status": "SAT"
+    },
+    {
+      "id": 274,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 279,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 284,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 289,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 294,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 299,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 304,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 309,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 314,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 319,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 324,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.132,
+      "status": "SAT"
+    },
+    {
+      "id": 329,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 334,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 339,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 344,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 349,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 354,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 359,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 364,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 369,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 374,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 379,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 384,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 389,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 394,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 399,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 404,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.158,
+      "status": "SAT"
+    },
+    {
+      "id": 409,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 414,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 419,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 424,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 429,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 434,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 439,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 444,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 449,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 454,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 459,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 464,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 469,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 474,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 479,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 484,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 489,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 494,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 499,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 504,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 509,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 514,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 519,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 524,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 529,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 534,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 539,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 544,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.055,
+      "status": "SAT"
+    },
+    {
+      "id": 549,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 554,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.191,
+      "status": "SAT"
+    },
+    {
+      "id": 559,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 564,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 569,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 574,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 579,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 584,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 589,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 594,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.054,
+      "status": "SAT"
+    },
+    {
+      "id": 599,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 604,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 609,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 614,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 619,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.052,
+      "status": "SAT"
+    },
+    {
+      "id": 624,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 629,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 634,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 639,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 644,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.053,
+      "status": "SAT"
+    },
+    {
+      "id": 649,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 654,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.29,
+      "status": "SAT"
+    },
+    {
+      "id": 659,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 664,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 669,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 674,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 679,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 684,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 689,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 694,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 699,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 704,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 709,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.266,
+      "status": "SAT"
+    },
+    {
+      "id": 714,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.363,
+      "status": "SAT"
+    },
+    {
+      "id": 719,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 724,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 729,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 734,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 739,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 744,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 749,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 754,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 759,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 764,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 769,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.249,
+      "status": "SAT"
+    },
+    {
+      "id": 774,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.286,
+      "status": "SAT"
+    },
+    {
+      "id": 779,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 784,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 789,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 794,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 799,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 804,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 809,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 814,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 819,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 824,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 829,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 834,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.285,
+      "status": "SAT"
+    },
+    {
+      "id": 839,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 844,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 849,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 854,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 859,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 864,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 869,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 874,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 879,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 884,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 889,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 894,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 899,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 904,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 909,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 914,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 919,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 924,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 929,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 934,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 939,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 944,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 949,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 954,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 959,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 964,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 969,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 974,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 979,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.287,
+      "status": "SAT"
+    },
+    {
+      "id": 984,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 989,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 994,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 999,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1004,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1009,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1014,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 1019,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1024,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1029,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1034,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1039,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1044,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1049,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1054,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.346,
+      "status": "SAT"
+    },
+    {
+      "id": 1059,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.226,
+      "status": "SAT"
+    },
+    {
+      "id": 1064,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1069,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1074,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1079,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.316,
+      "status": "SAT"
+    },
+    {
+      "id": 1084,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.231,
+      "status": "SAT"
+    },
+    {
+      "id": 1089,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1094,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1099,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1104,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1109,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1114,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1119,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1124,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1129,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.271,
+      "status": "SAT"
+    },
+    {
+      "id": 1134,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1139,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1144,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.484,
+      "status": "SAT"
+    },
+    {
+      "id": 1149,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1154,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.301,
+      "status": "SAT"
+    },
+    {
+      "id": 1159,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.193,
+      "status": "SAT"
+    },
+    {
+      "id": 1164,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1169,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1174,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1179,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.047,
+      "status": "SAT"
+    },
+    {
+      "id": 1184,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1189,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1194,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1199,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1204,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.229,
+      "status": "SAT"
+    },
+    {
+      "id": 1209,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 1214,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.256,
+      "status": "SAT"
+    },
+    {
+      "id": 1219,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 1224,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1229,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.256,
+      "status": "SAT"
+    },
+    {
+      "id": 1234,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 1239,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1244,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1249,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1254,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1259,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1264,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1269,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1274,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1279,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.208,
+      "status": "SAT"
+    },
+    {
+      "id": 1284,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 1289,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1294,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.342,
+      "status": "SAT"
+    },
+    {
+      "id": 1299,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1304,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.053,
+      "status": "SAT"
+    },
+    {
+      "id": 1309,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.053,
+      "status": "SAT"
+    },
+    {
+      "id": 1314,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 1319,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 1324,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1329,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.161,
+      "status": "SAT"
+    },
+    {
+      "id": 1334,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1339,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1344,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1349,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1354,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.233,
+      "status": "SAT"
+    },
+    {
+      "id": 1359,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 1364,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.241,
+      "status": "SAT"
+    },
+    {
+      "id": 1369,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1374,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1379,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 1384,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1389,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1394,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1399,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1404,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1409,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 1414,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1419,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1424,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1429,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.286,
+      "status": "SAT"
+    },
+    {
+      "id": 1434,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1439,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.262,
+      "status": "SAT"
+    },
+    {
+      "id": 1444,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1449,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1454,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1459,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1464,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1469,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1474,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1479,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1484,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.052,
+      "status": "SAT"
+    },
+    {
+      "id": 1489,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1494,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1499,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1504,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.287,
+      "status": "SAT"
+    },
+    {
+      "id": 1509,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1514,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.279,
+      "status": "SAT"
+    },
+    {
+      "id": 1519,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1524,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1529,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.055,
+      "status": "SAT"
+    },
+    {
+      "id": 1534,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 1539,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1544,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1549,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1554,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1559,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1564,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1569,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1574,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1579,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.181,
+      "status": "SAT"
+    },
+    {
+      "id": 1584,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1589,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 1594,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1599,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1604,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1609,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1614,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1619,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1624,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1629,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1634,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1639,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1644,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1649,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.146,
+      "status": "SAT"
+    },
+    {
+      "id": 1654,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1659,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.152,
+      "status": "SAT"
+    },
+    {
+      "id": 1664,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 1669,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1674,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1679,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1684,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1689,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1694,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1699,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1704,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 1709,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1714,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1719,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1724,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1729,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.206,
+      "status": "SAT"
+    },
+    {
+      "id": 1734,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 1739,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.165,
+      "status": "SAT"
+    },
+    {
+      "id": 1744,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1749,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1754,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 1759,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1764,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.052,
+      "status": "SAT"
+    },
+    {
+      "id": 1769,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1774,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1779,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1784,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1789,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1794,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1799,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1804,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.207,
+      "status": "SAT"
+    },
+    {
+      "id": 1809,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 1814,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1819,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1824,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1829,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1834,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1839,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1844,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1849,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1854,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.178,
+      "status": "SAT"
+    },
+    {
+      "id": 1859,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1864,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1869,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 1874,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1879,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.331,
+      "status": "SAT"
+    },
+    {
+      "id": 1884,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 1889,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1894,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1899,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1904,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1909,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1914,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1919,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1924,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1929,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 1934,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1939,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1944,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1949,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1954,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.242,
+      "status": "SAT"
+    },
+    {
+      "id": 1959,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1964,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1969,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.215,
+      "status": "SAT"
+    },
+    {
+      "id": 1974,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1979,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1984,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 1989,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1994,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1999,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2004,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 2009,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 2014,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2019,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.053,
+      "status": "SAT"
+    },
+    {
+      "id": 2024,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.196,
+      "status": "SAT"
+    },
+    {
+      "id": 2029,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.228,
+      "status": "SAT"
+    },
+    {
+      "id": 2034,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 2039,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2044,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2049,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2054,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2059,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2064,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2069,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2074,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2079,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2084,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2089,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 2094,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2099,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.257,
+      "status": "SAT"
+    },
+    {
+      "id": 2104,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 2109,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2114,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2119,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2124,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2129,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2134,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2139,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.054,
+      "status": "SAT"
+    },
+    {
+      "id": 2144,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 2149,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2154,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 2159,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2164,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.185,
+      "status": "SAT"
+    },
+    {
+      "id": 2169,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 2174,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2179,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.198,
+      "status": "SAT"
+    },
+    {
+      "id": 2184,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2189,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2194,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2199,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2204,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2209,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2214,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 2219,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2224,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 2229,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2234,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2239,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.213,
+      "status": "SAT"
+    },
+    {
+      "id": 2244,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2249,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2254,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 2259,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2264,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 2269,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2274,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2279,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 2284,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2289,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2294,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.161,
+      "status": "SAT"
+    },
+    {
+      "id": 2299,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2304,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 2309,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2314,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2319,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2324,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2329,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.159,
+      "status": "SAT"
+    },
+    {
+      "id": 2334,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 2339,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2344,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.162,
+      "status": "SAT"
+    },
+    {
+      "id": 2349,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2354,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 2359,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2364,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 2369,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2374,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2379,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.157,
+      "status": "SAT"
+    },
+    {
+      "id": 2384,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.134,
+      "status": "SAT"
+    },
+    {
+      "id": 2389,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2394,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 2399,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2404,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 2409,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2414,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2419,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 2424,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2429,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.201,
+      "status": "SAT"
+    },
+    {
+      "id": 2434,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 2439,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2444,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 2449,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_weak_left_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_weak_left_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 3,
+  "onnx_path": "networks/aprev_weak_left.onnx",
+  "mode": "continuous",
+  "timestamp": "2026-04-15T14:03:55.213856",
+  "timeout_sec": 30,
+  "total_wall_sec": 7078.202,
+  "avg_sat_sec": 0.102,
+  "summary": {
+    "SAT": 255,
+    "UNSAT": 0,
+    "TIMEOUT": 235,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 3,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.067,
+      "status": "SAT"
+    },
+    {
+      "id": 8,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 13,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 18,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 23,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 28,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 33,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 38,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 43,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 48,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.268,
+      "status": "SAT"
+    },
+    {
+      "id": 53,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 58,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 63,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 68,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 73,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 78,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 83,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 88,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 93,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 98,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 103,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 108,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 113,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 118,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 123,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 128,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 133,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 138,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 143,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 148,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.187,
+      "status": "SAT"
+    },
+    {
+      "id": 153,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 158,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 163,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 168,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 173,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.202,
+      "status": "SAT"
+    },
+    {
+      "id": 178,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 183,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 188,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 193,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.169,
+      "status": "SAT"
+    },
+    {
+      "id": 198,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 203,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 208,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 213,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 218,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 223,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 228,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 233,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 238,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.221,
+      "status": "SAT"
+    },
+    {
+      "id": 243,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 248,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 253,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 258,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 263,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 268,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 273,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 278,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 283,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.284,
+      "status": "SAT"
+    },
+    {
+      "id": 288,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 293,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 298,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 303,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 308,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 313,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 318,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.183,
+      "status": "SAT"
+    },
+    {
+      "id": 323,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 328,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.18,
+      "status": "SAT"
+    },
+    {
+      "id": 333,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 338,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 343,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 348,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 353,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 358,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 363,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 368,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 373,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.34,
+      "status": "SAT"
+    },
+    {
+      "id": 378,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 383,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 388,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 393,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 398,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 403,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 408,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.19,
+      "status": "SAT"
+    },
+    {
+      "id": 413,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 418,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 423,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.215,
+      "status": "SAT"
+    },
+    {
+      "id": 428,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 433,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 438,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 443,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 448,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 453,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 458,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 463,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 468,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 473,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 478,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 483,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.145,
+      "status": "SAT"
+    },
+    {
+      "id": 488,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 493,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 498,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 503,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 508,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.171,
+      "status": "SAT"
+    },
+    {
+      "id": 513,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 518,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 523,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 528,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 533,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 538,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 543,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 548,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 553,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 558,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 563,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 568,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 573,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 578,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 583,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 588,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 593,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 598,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 603,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.184,
+      "status": "SAT"
+    },
+    {
+      "id": 608,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.161,
+      "status": "SAT"
+    },
+    {
+      "id": 613,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 618,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 623,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.248,
+      "status": "SAT"
+    },
+    {
+      "id": 628,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 633,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 638,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.133,
+      "status": "SAT"
+    },
+    {
+      "id": 643,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 648,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.168,
+      "status": "SAT"
+    },
+    {
+      "id": 653,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 658,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 663,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 668,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 673,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.251,
+      "status": "SAT"
+    },
+    {
+      "id": 678,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 683,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 688,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 693,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 698,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 703,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 708,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 713,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 718,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 723,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 728,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 733,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 738,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 743,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 748,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 753,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.15,
+      "status": "SAT"
+    },
+    {
+      "id": 758,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 763,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.036,
+      "status": "SAT"
+    },
+    {
+      "id": 768,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 773,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 778,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 783,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 788,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 793,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 798,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 803,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 808,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 813,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.153,
+      "status": "SAT"
+    },
+    {
+      "id": 818,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 823,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 828,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 833,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 838,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 843,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 848,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 853,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 858,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 863,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 868,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 873,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 878,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 883,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 888,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 893,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 898,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.036,
+      "status": "SAT"
+    },
+    {
+      "id": 903,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 908,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 913,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 918,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 923,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 928,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 933,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 938,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 943,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 948,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 953,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 958,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 963,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 968,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 973,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 978,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 983,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 988,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 993,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 998,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1003,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.045,
+      "status": "SAT"
+    },
+    {
+      "id": 1008,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1013,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1018,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1023,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.046,
+      "status": "SAT"
+    },
+    {
+      "id": 1028,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1033,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1038,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1043,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1048,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1053,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1058,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1063,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1068,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1073,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1078,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1083,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1088,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1093,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1098,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.257,
+      "status": "SAT"
+    },
+    {
+      "id": 1103,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1108,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 1113,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 1118,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.05,
+      "status": "SAT"
+    },
+    {
+      "id": 1123,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.051,
+      "status": "SAT"
+    },
+    {
+      "id": 1128,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1133,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1138,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.195,
+      "status": "SAT"
+    },
+    {
+      "id": 1143,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1148,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.16,
+      "status": "SAT"
+    },
+    {
+      "id": 1153,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1158,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.263,
+      "status": "SAT"
+    },
+    {
+      "id": 1163,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1168,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1173,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.018,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1178,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1183,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1188,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1193,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1198,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1203,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1208,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.182,
+      "status": "SAT"
+    },
+    {
+      "id": 1213,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 1218,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1223,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1228,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1233,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.25,
+      "status": "SAT"
+    },
+    {
+      "id": 1238,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1243,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1248,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1253,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1258,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 1263,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1268,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1273,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1278,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1283,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.288,
+      "status": "SAT"
+    },
+    {
+      "id": 1288,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1293,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1298,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1303,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1308,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1313,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1318,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1323,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1328,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 1333,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.214,
+      "status": "SAT"
+    },
+    {
+      "id": 1338,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1343,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1348,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1353,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1358,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.213,
+      "status": "SAT"
+    },
+    {
+      "id": 1363,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.167,
+      "status": "SAT"
+    },
+    {
+      "id": 1368,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1373,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.173,
+      "status": "SAT"
+    },
+    {
+      "id": 1378,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1383,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.001,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1388,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1393,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1398,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1403,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.149,
+      "status": "SAT"
+    },
+    {
+      "id": 1408,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1413,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.046,
+      "status": "SAT"
+    },
+    {
+      "id": 1418,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1423,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.044,
+      "status": "SAT"
+    },
+    {
+      "id": 1428,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1433,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.188,
+      "status": "SAT"
+    },
+    {
+      "id": 1438,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.134,
+      "status": "SAT"
+    },
+    {
+      "id": 1443,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1448,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.154,
+      "status": "SAT"
+    },
+    {
+      "id": 1453,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1458,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.172,
+      "status": "SAT"
+    },
+    {
+      "id": 1463,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1468,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1473,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1478,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 1483,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1488,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 1493,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1498,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 1503,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1508,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1513,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.164,
+      "status": "SAT"
+    },
+    {
+      "id": 1518,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1523,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1528,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1533,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1538,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1543,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1548,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1553,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1558,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1563,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 1568,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1573,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 1578,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.166,
+      "status": "SAT"
+    },
+    {
+      "id": 1583,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1588,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1593,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1598,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1603,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1608,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1613,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1618,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1623,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 1628,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1633,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1638,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1643,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1648,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.174,
+      "status": "SAT"
+    },
+    {
+      "id": 1653,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.158,
+      "status": "SAT"
+    },
+    {
+      "id": 1658,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1663,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.145,
+      "status": "SAT"
+    },
+    {
+      "id": 1668,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 30.019,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1673,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 1678,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1683,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1688,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1693,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1698,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 1703,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1708,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1713,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1718,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1723,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.177,
+      "status": "SAT"
+    },
+    {
+      "id": 1728,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 1733,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1738,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1743,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1748,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.145,
+      "status": "SAT"
+    },
+    {
+      "id": 1753,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1758,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1763,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1768,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1773,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1778,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1783,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 1788,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1793,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1798,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 1803,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.17,
+      "status": "SAT"
+    },
+    {
+      "id": 1808,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1813,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 1818,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1823,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.158,
+      "status": "SAT"
+    },
+    {
+      "id": 1828,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1833,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1838,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1843,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1848,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1853,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1858,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 1863,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1868,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.136,
+      "status": "SAT"
+    },
+    {
+      "id": 1873,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.176,
+      "status": "SAT"
+    },
+    {
+      "id": 1878,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1883,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1888,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1893,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1898,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.175,
+      "status": "SAT"
+    },
+    {
+      "id": 1903,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1908,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1913,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1918,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1923,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1928,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1933,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1938,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1943,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1948,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 1953,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1958,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.017,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1963,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1968,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1973,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.228,
+      "status": "SAT"
+    },
+    {
+      "id": 1978,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1983,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 1988,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.037,
+      "status": "SAT"
+    },
+    {
+      "id": 1993,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 1998,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2003,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2008,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.049,
+      "status": "SAT"
+    },
+    {
+      "id": 2013,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.009,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2018,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.041,
+      "status": "SAT"
+    },
+    {
+      "id": 2023,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2028,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2033,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2038,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2043,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2048,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.219,
+      "status": "SAT"
+    },
+    {
+      "id": 2053,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2058,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2063,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2068,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2073,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.143,
+      "status": "SAT"
+    },
+    {
+      "id": 2078,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2083,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2088,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.043,
+      "status": "SAT"
+    },
+    {
+      "id": 2093,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 2098,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2103,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2108,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2113,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2118,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.226,
+      "status": "SAT"
+    },
+    {
+      "id": 2123,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2128,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2133,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2138,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 2143,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2148,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2153,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2158,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.137,
+      "status": "SAT"
+    },
+    {
+      "id": 2163,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.01,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2168,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2173,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2178,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2183,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.246,
+      "status": "SAT"
+    },
+    {
+      "id": 2188,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2193,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.038,
+      "status": "SAT"
+    },
+    {
+      "id": 2198,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.139,
+      "status": "SAT"
+    },
+    {
+      "id": 2203,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.14,
+      "status": "SAT"
+    },
+    {
+      "id": 2208,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2213,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.144,
+      "status": "SAT"
+    },
+    {
+      "id": 2218,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.135,
+      "status": "SAT"
+    },
+    {
+      "id": 2223,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2228,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2233,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.007,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2238,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.004,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2243,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.221,
+      "status": "SAT"
+    },
+    {
+      "id": 2248,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2253,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 2258,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2263,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2268,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 2273,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.138,
+      "status": "SAT"
+    },
+    {
+      "id": 2278,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.008,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2283,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2288,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2293,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.016,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2298,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.235,
+      "status": "SAT"
+    },
+    {
+      "id": 2303,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.147,
+      "status": "SAT"
+    },
+    {
+      "id": 2308,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2313,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.019,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2318,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.142,
+      "status": "SAT"
+    },
+    {
+      "id": 2323,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.141,
+      "status": "SAT"
+    },
+    {
+      "id": 2328,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2333,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.005,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2338,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.013,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2343,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.006,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2348,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.186,
+      "status": "SAT"
+    },
+    {
+      "id": 2353,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.04,
+      "status": "SAT"
+    },
+    {
+      "id": 2358,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2363,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.002,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2368,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 2373,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.155,
+      "status": "SAT"
+    },
+    {
+      "id": 2378,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.011,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2383,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.213,
+      "status": "SAT"
+    },
+    {
+      "id": 2388,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.003,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2393,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2398,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.204,
+      "status": "SAT"
+    },
+    {
+      "id": 2403,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2408,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.039,
+      "status": "SAT"
+    },
+    {
+      "id": 2413,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 30.015,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2418,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.042,
+      "status": "SAT"
+    },
+    {
+      "id": 2423,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.156,
+      "status": "SAT"
+    },
+    {
+      "id": 2428,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2433,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.189,
+      "status": "SAT"
+    },
+    {
+      "id": 2438,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 30.014,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2443,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 30.012,
+      "status": "TIMEOUT"
+    },
+    {
+      "id": 2448,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.217,
+      "status": "SAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_weak_right_crown_results.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/contracts/continuous_goals/enabled_pgd/aprev_weak_right_crown_results.json
@@ -1,0 +1,17707 @@
+{
+  "network_idx": 2,
+  "onnx_path": "networks/aprev_weak_right.onnx",
+  "mode": "continuous",
+  "timestamp": "2026-04-15T12:05:53.126135",
+  "timeout_sec": 30,
+  "total_wall_sec": 262.839,
+  "avg_sat_sec": 0.782,
+  "summary": {
+    "SAT": 323,
+    "UNSAT": 167,
+    "TIMEOUT": 0,
+    "total": 490
+  },
+  "contracts": [
+    {
+      "id": 2,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 1.085,
+      "status": "SAT"
+    },
+    {
+      "id": 7,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "SAT"
+    },
+    {
+      "id": 12,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.53,
+      "status": "SAT"
+    },
+    {
+      "id": 17,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.485,
+      "status": "SAT"
+    },
+    {
+      "id": 22,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 27,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.88,
+      "status": "SAT"
+    },
+    {
+      "id": 32,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.652,
+      "status": "SAT"
+    },
+    {
+      "id": 37,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.753,
+      "status": "SAT"
+    },
+    {
+      "id": 42,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.712,
+      "status": "SAT"
+    },
+    {
+      "id": 47,
+      "heading_own_var": 0,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 52,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.59,
+      "status": "SAT"
+    },
+    {
+      "id": 57,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.577,
+      "status": "SAT"
+    },
+    {
+      "id": 62,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.554,
+      "status": "SAT"
+    },
+    {
+      "id": 67,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "SAT"
+    },
+    {
+      "id": 72,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 77,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.937,
+      "status": "SAT"
+    },
+    {
+      "id": 82,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.779,
+      "status": "SAT"
+    },
+    {
+      "id": 87,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.762,
+      "status": "SAT"
+    },
+    {
+      "id": 92,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.74,
+      "status": "SAT"
+    },
+    {
+      "id": 97,
+      "heading_own_var": 1,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 102,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.486,
+      "status": "SAT"
+    },
+    {
+      "id": 107,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.495,
+      "status": "SAT"
+    },
+    {
+      "id": 112,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.491,
+      "status": "SAT"
+    },
+    {
+      "id": 117,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.558,
+      "status": "SAT"
+    },
+    {
+      "id": 122,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 127,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.874,
+      "status": "SAT"
+    },
+    {
+      "id": 132,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.752,
+      "status": "SAT"
+    },
+    {
+      "id": 137,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.848,
+      "status": "SAT"
+    },
+    {
+      "id": 142,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.808,
+      "status": "SAT"
+    },
+    {
+      "id": 147,
+      "heading_own_var": 2,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 152,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.58,
+      "status": "SAT"
+    },
+    {
+      "id": 157,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.552,
+      "status": "SAT"
+    },
+    {
+      "id": 162,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.526,
+      "status": "SAT"
+    },
+    {
+      "id": 167,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 172,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.802,
+      "status": "SAT"
+    },
+    {
+      "id": 177,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.677,
+      "status": "SAT"
+    },
+    {
+      "id": 182,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.811,
+      "status": "SAT"
+    },
+    {
+      "id": 187,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 192,
+      "heading_own_var": 3,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 197,
+      "heading_own_var": 4,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "SAT"
+    },
+    {
+      "id": 202,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.516,
+      "status": "SAT"
+    },
+    {
+      "id": 207,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "SAT"
+    },
+    {
+      "id": 212,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 217,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.803,
+      "status": "SAT"
+    },
+    {
+      "id": 222,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.656,
+      "status": "SAT"
+    },
+    {
+      "id": 227,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.755,
+      "status": "SAT"
+    },
+    {
+      "id": 232,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.723,
+      "status": "SAT"
+    },
+    {
+      "id": 237,
+      "heading_own_var": 4,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 242,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "SAT"
+    },
+    {
+      "id": 247,
+      "heading_own_var": 5,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.51,
+      "status": "SAT"
+    },
+    {
+      "id": 252,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.573,
+      "status": "SAT"
+    },
+    {
+      "id": 257,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 262,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.722,
+      "status": "SAT"
+    },
+    {
+      "id": 267,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.684,
+      "status": "SAT"
+    },
+    {
+      "id": 272,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.74,
+      "status": "SAT"
+    },
+    {
+      "id": 277,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.717,
+      "status": "SAT"
+    },
+    {
+      "id": 282,
+      "heading_own_var": 5,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 287,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.527,
+      "status": "SAT"
+    },
+    {
+      "id": 292,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.507,
+      "status": "SAT"
+    },
+    {
+      "id": 297,
+      "heading_own_var": 6,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.496,
+      "status": "SAT"
+    },
+    {
+      "id": 302,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.515,
+      "status": "SAT"
+    },
+    {
+      "id": 307,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.813,
+      "status": "SAT"
+    },
+    {
+      "id": 312,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.722,
+      "status": "SAT"
+    },
+    {
+      "id": 317,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.69,
+      "status": "SAT"
+    },
+    {
+      "id": 322,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.636,
+      "status": "SAT"
+    },
+    {
+      "id": 327,
+      "heading_own_var": 6,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 332,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.497,
+      "status": "SAT"
+    },
+    {
+      "id": 337,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.549,
+      "status": "SAT"
+    },
+    {
+      "id": 342,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.541,
+      "status": "SAT"
+    },
+    {
+      "id": 347,
+      "heading_own_var": 7,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 352,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.701,
+      "status": "SAT"
+    },
+    {
+      "id": 357,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.777,
+      "status": "SAT"
+    },
+    {
+      "id": 362,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 15,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ],
+        [
+          4,
+          4
+        ]
+      ],
+      "wall_sec": 0.751,
+      "status": "SAT"
+    },
+    {
+      "id": 367,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.715,
+      "status": "SAT"
+    },
+    {
+      "id": 372,
+      "heading_own_var": 7,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 377,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.556,
+      "status": "SAT"
+    },
+    {
+      "id": 382,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.543,
+      "status": "SAT"
+    },
+    {
+      "id": 387,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.484,
+      "status": "SAT"
+    },
+    {
+      "id": 392,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.5,
+      "status": "SAT"
+    },
+    {
+      "id": 397,
+      "heading_own_var": 8,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 402,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.644,
+      "status": "SAT"
+    },
+    {
+      "id": 407,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.543,
+      "status": "SAT"
+    },
+    {
+      "id": 412,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.69,
+      "status": "SAT"
+    },
+    {
+      "id": 417,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.555,
+      "status": "SAT"
+    },
+    {
+      "id": 422,
+      "heading_own_var": 8,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 427,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.569,
+      "status": "SAT"
+    },
+    {
+      "id": 432,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.592,
+      "status": "SAT"
+    },
+    {
+      "id": 437,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.514,
+      "status": "SAT"
+    },
+    {
+      "id": 442,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.509,
+      "status": "SAT"
+    },
+    {
+      "id": 447,
+      "heading_own_var": 9,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 452,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.728,
+      "status": "SAT"
+    },
+    {
+      "id": 457,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.52,
+      "status": "SAT"
+    },
+    {
+      "id": 462,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.789,
+      "status": "SAT"
+    },
+    {
+      "id": 467,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.613,
+      "status": "SAT"
+    },
+    {
+      "id": 472,
+      "heading_own_var": 9,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 477,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.593,
+      "status": "SAT"
+    },
+    {
+      "id": 482,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 487,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 492,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.564,
+      "status": "SAT"
+    },
+    {
+      "id": 497,
+      "heading_own_var": 10,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 502,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.732,
+      "status": "SAT"
+    },
+    {
+      "id": 507,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.618,
+      "status": "SAT"
+    },
+    {
+      "id": 512,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.73,
+      "status": "SAT"
+    },
+    {
+      "id": 517,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.566,
+      "status": "SAT"
+    },
+    {
+      "id": 522,
+      "heading_own_var": 10,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.008,
+      "status": "UNSAT"
+    },
+    {
+      "id": 527,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.684,
+      "status": "SAT"
+    },
+    {
+      "id": 532,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.648,
+      "status": "SAT"
+    },
+    {
+      "id": 537,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.574,
+      "status": "SAT"
+    },
+    {
+      "id": 542,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.583,
+      "status": "SAT"
+    },
+    {
+      "id": 547,
+      "heading_own_var": 11,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 552,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.653,
+      "status": "SAT"
+    },
+    {
+      "id": 557,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.602,
+      "status": "SAT"
+    },
+    {
+      "id": 562,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.596,
+      "status": "SAT"
+    },
+    {
+      "id": 567,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.625,
+      "status": "SAT"
+    },
+    {
+      "id": 572,
+      "heading_own_var": 11,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 577,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.6,
+      "status": "SAT"
+    },
+    {
+      "id": 582,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.482,
+      "status": "SAT"
+    },
+    {
+      "id": 587,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.637,
+      "status": "SAT"
+    },
+    {
+      "id": 592,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.647,
+      "status": "SAT"
+    },
+    {
+      "id": 597,
+      "heading_own_var": 12,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 602,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.641,
+      "status": "SAT"
+    },
+    {
+      "id": 607,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.606,
+      "status": "SAT"
+    },
+    {
+      "id": 612,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.401,
+      "status": "SAT"
+    },
+    {
+      "id": 617,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.722,
+      "status": "SAT"
+    },
+    {
+      "id": 622,
+      "heading_own_var": 12,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 627,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.652,
+      "status": "SAT"
+    },
+    {
+      "id": 632,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "SAT"
+    },
+    {
+      "id": 637,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ]
+      ],
+      "wall_sec": 0.752,
+      "status": "SAT"
+    },
+    {
+      "id": 642,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.61,
+      "status": "SAT"
+    },
+    {
+      "id": 647,
+      "heading_own_var": 13,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 652,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.299,
+      "status": "SAT"
+    },
+    {
+      "id": 657,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.201,
+      "status": "SAT"
+    },
+    {
+      "id": 662,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          3,
+          4
+        ]
+      ],
+      "wall_sec": 1.007,
+      "status": "SAT"
+    },
+    {
+      "id": 667,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.21,
+      "status": "UNSAT"
+    },
+    {
+      "id": 672,
+      "heading_own_var": 13,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 677,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.625,
+      "status": "SAT"
+    },
+    {
+      "id": 682,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.628,
+      "status": "SAT"
+    },
+    {
+      "id": 687,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.61,
+      "status": "SAT"
+    },
+    {
+      "id": 692,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.558,
+      "status": "SAT"
+    },
+    {
+      "id": 697,
+      "heading_own_var": 14,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 702,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 707,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.343,
+      "status": "SAT"
+    },
+    {
+      "id": 712,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.946,
+      "status": "SAT"
+    },
+    {
+      "id": 717,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.25,
+      "status": "SAT"
+    },
+    {
+      "id": 722,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.45,
+      "status": "UNSAT"
+    },
+    {
+      "id": 727,
+      "heading_own_var": 14,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 732,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.698,
+      "status": "SAT"
+    },
+    {
+      "id": 737,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.628,
+      "status": "SAT"
+    },
+    {
+      "id": 742,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.596,
+      "status": "SAT"
+    },
+    {
+      "id": 747,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.611,
+      "status": "SAT"
+    },
+    {
+      "id": 752,
+      "heading_own_var": 15,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 757,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.661,
+      "status": "SAT"
+    },
+    {
+      "id": 762,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.737,
+      "status": "SAT"
+    },
+    {
+      "id": 767,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.249,
+      "status": "SAT"
+    },
+    {
+      "id": 772,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.308,
+      "status": "SAT"
+    },
+    {
+      "id": 777,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.289,
+      "status": "SAT"
+    },
+    {
+      "id": 782,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.391,
+      "status": "SAT"
+    },
+    {
+      "id": 787,
+      "heading_own_var": 15,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 792,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.73,
+      "status": "SAT"
+    },
+    {
+      "id": 797,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.61,
+      "status": "SAT"
+    },
+    {
+      "id": 802,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.687,
+      "status": "SAT"
+    },
+    {
+      "id": 807,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.774,
+      "status": "SAT"
+    },
+    {
+      "id": 812,
+      "heading_own_var": 16,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 817,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.627,
+      "status": "SAT"
+    },
+    {
+      "id": 822,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.532,
+      "status": "SAT"
+    },
+    {
+      "id": 827,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.481,
+      "status": "SAT"
+    },
+    {
+      "id": 832,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.315,
+      "status": "SAT"
+    },
+    {
+      "id": 837,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.217,
+      "status": "SAT"
+    },
+    {
+      "id": 842,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.268,
+      "status": "SAT"
+    },
+    {
+      "id": 847,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.457,
+      "status": "SAT"
+    },
+    {
+      "id": 852,
+      "heading_own_var": 16,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 857,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.804,
+      "status": "SAT"
+    },
+    {
+      "id": 862,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.839,
+      "status": "SAT"
+    },
+    {
+      "id": 867,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ]
+      ],
+      "wall_sec": 0.829,
+      "status": "SAT"
+    },
+    {
+      "id": 872,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.815,
+      "status": "SAT"
+    },
+    {
+      "id": 877,
+      "heading_own_var": 17,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 882,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.643,
+      "status": "SAT"
+    },
+    {
+      "id": 887,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.559,
+      "status": "SAT"
+    },
+    {
+      "id": 892,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.551,
+      "status": "SAT"
+    },
+    {
+      "id": 897,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 902,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.685,
+      "status": "SAT"
+    },
+    {
+      "id": 907,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.036,
+      "status": "SAT"
+    },
+    {
+      "id": 912,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          0,
+          4
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          1,
+          4
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          2,
+          4
+        ]
+      ],
+      "wall_sec": 1.379,
+      "status": "SAT"
+    },
+    {
+      "id": 917,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.452,
+      "status": "SAT"
+    },
+    {
+      "id": 922,
+      "heading_own_var": 17,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 927,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.473,
+      "status": "SAT"
+    },
+    {
+      "id": 932,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.667,
+      "status": "SAT"
+    },
+    {
+      "id": 937,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.533,
+      "status": "SAT"
+    },
+    {
+      "id": 942,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.666,
+      "status": "SAT"
+    },
+    {
+      "id": 947,
+      "heading_own_var": 18,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 952,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.68,
+      "status": "SAT"
+    },
+    {
+      "id": 957,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.579,
+      "status": "SAT"
+    },
+    {
+      "id": 962,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.685,
+      "status": "SAT"
+    },
+    {
+      "id": 967,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.722,
+      "status": "SAT"
+    },
+    {
+      "id": 972,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 977,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.419,
+      "status": "SAT"
+    },
+    {
+      "id": 982,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.242,
+      "status": "SAT"
+    },
+    {
+      "id": 987,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.274,
+      "status": "SAT"
+    },
+    {
+      "id": 992,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 997,
+      "heading_own_var": 18,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1002,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.63,
+      "status": "SAT"
+    },
+    {
+      "id": 1007,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.477,
+      "status": "SAT"
+    },
+    {
+      "id": 1012,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.566,
+      "status": "SAT"
+    },
+    {
+      "id": 1017,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.588,
+      "status": "SAT"
+    },
+    {
+      "id": 1022,
+      "heading_own_var": 19,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1027,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.514,
+      "status": "SAT"
+    },
+    {
+      "id": 1032,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.645,
+      "status": "SAT"
+    },
+    {
+      "id": 1037,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 1042,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.76,
+      "status": "SAT"
+    },
+    {
+      "id": 1047,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1052,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.7,
+      "status": "SAT"
+    },
+    {
+      "id": 1057,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.3,
+      "status": "SAT"
+    },
+    {
+      "id": 1062,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.316,
+      "status": "SAT"
+    },
+    {
+      "id": 1067,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1072,
+      "heading_own_var": 19,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1077,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.394,
+      "status": "SAT"
+    },
+    {
+      "id": 1082,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.955,
+      "status": "SAT"
+    },
+    {
+      "id": 1087,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.071,
+      "status": "SAT"
+    },
+    {
+      "id": 1092,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1097,
+      "heading_own_var": 20,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1102,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.675,
+      "status": "SAT"
+    },
+    {
+      "id": 1107,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.794,
+      "status": "SAT"
+    },
+    {
+      "id": 1112,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.778,
+      "status": "SAT"
+    },
+    {
+      "id": 1117,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.729,
+      "status": "SAT"
+    },
+    {
+      "id": 1122,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1127,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.134,
+      "status": "SAT"
+    },
+    {
+      "id": 1132,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.023,
+      "status": "SAT"
+    },
+    {
+      "id": 1137,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.751,
+      "status": "SAT"
+    },
+    {
+      "id": 1142,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.064,
+      "status": "SAT"
+    },
+    {
+      "id": 1147,
+      "heading_own_var": 20,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1152,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.983,
+      "status": "SAT"
+    },
+    {
+      "id": 1157,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 1.157,
+      "status": "SAT"
+    },
+    {
+      "id": 1162,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.225,
+      "status": "SAT"
+    },
+    {
+      "id": 1167,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1172,
+      "heading_own_var": 21,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1177,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.486,
+      "status": "SAT"
+    },
+    {
+      "id": 1182,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.614,
+      "status": "SAT"
+    },
+    {
+      "id": 1187,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.611,
+      "status": "SAT"
+    },
+    {
+      "id": 1192,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1197,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.028,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1202,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.374,
+      "status": "SAT"
+    },
+    {
+      "id": 1207,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.858,
+      "status": "SAT"
+    },
+    {
+      "id": 1212,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.978,
+      "status": "SAT"
+    },
+    {
+      "id": 1217,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1222,
+      "heading_own_var": 21,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1227,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 1.351,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1232,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 1.38,
+      "status": "SAT"
+    },
+    {
+      "id": 1237,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 1.186,
+      "status": "SAT"
+    },
+    {
+      "id": 1242,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1247,
+      "heading_own_var": 22,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1252,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1257,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.732,
+      "status": "SAT"
+    },
+    {
+      "id": 1262,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.798,
+      "status": "SAT"
+    },
+    {
+      "id": 1267,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.029,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1272,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.567,
+      "status": "SAT"
+    },
+    {
+      "id": 1277,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.113,
+      "status": "SAT"
+    },
+    {
+      "id": 1282,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.012,
+      "status": "SAT"
+    },
+    {
+      "id": 1287,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 1.207,
+      "status": "SAT"
+    },
+    {
+      "id": 1292,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1297,
+      "heading_own_var": 22,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1302,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.996,
+      "status": "SAT"
+    },
+    {
+      "id": 1307,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.528,
+      "status": "SAT"
+    },
+    {
+      "id": 1312,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ]
+      ],
+      "wall_sec": 0.682,
+      "status": "SAT"
+    },
+    {
+      "id": 1317,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.894,
+      "status": "SAT"
+    },
+    {
+      "id": 1322,
+      "heading_own_var": 23,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1327,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1332,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.663,
+      "status": "SAT"
+    },
+    {
+      "id": 1337,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ]
+      ],
+      "wall_sec": 0.72,
+      "status": "SAT"
+    },
+    {
+      "id": 1342,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1347,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1352,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.017,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1357,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.75,
+      "status": "SAT"
+    },
+    {
+      "id": 1362,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          0,
+          3
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ]
+      ],
+      "wall_sec": 0.749,
+      "status": "SAT"
+    },
+    {
+      "id": 1367,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1372,
+      "heading_own_var": 23,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1377,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 1.102,
+      "status": "SAT"
+    },
+    {
+      "id": 1382,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.779,
+      "status": "SAT"
+    },
+    {
+      "id": 1387,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.653,
+      "status": "SAT"
+    },
+    {
+      "id": 1392,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.624,
+      "status": "SAT"
+    },
+    {
+      "id": 1397,
+      "heading_own_var": 24,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1402,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.021,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1407,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.958,
+      "status": "SAT"
+    },
+    {
+      "id": 1412,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.74,
+      "status": "SAT"
+    },
+    {
+      "id": 1417,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1422,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1427,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.017,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1432,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.8,
+      "status": "SAT"
+    },
+    {
+      "id": 1437,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.747,
+      "status": "SAT"
+    },
+    {
+      "id": 1442,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1447,
+      "heading_own_var": 24,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1452,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.754,
+      "status": "SAT"
+    },
+    {
+      "id": 1457,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.636,
+      "status": "SAT"
+    },
+    {
+      "id": 1462,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.593,
+      "status": "SAT"
+    },
+    {
+      "id": 1467,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.624,
+      "status": "SAT"
+    },
+    {
+      "id": 1472,
+      "heading_own_var": 25,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1477,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.068,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1482,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.755,
+      "status": "SAT"
+    },
+    {
+      "id": 1487,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.907,
+      "status": "SAT"
+    },
+    {
+      "id": 1492,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1497,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1502,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.028,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1507,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.988,
+      "status": "SAT"
+    },
+    {
+      "id": 1512,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.84,
+      "status": "SAT"
+    },
+    {
+      "id": 1517,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1522,
+      "heading_own_var": 25,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1527,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 1.65,
+      "status": "SAT"
+    },
+    {
+      "id": 1532,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.71,
+      "status": "SAT"
+    },
+    {
+      "id": 1537,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.806,
+      "status": "SAT"
+    },
+    {
+      "id": 1542,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.792,
+      "status": "SAT"
+    },
+    {
+      "id": 1547,
+      "heading_own_var": 26,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1552,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 1.048,
+      "status": "SAT"
+    },
+    {
+      "id": 1557,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.867,
+      "status": "SAT"
+    },
+    {
+      "id": 1562,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 1.04,
+      "status": "SAT"
+    },
+    {
+      "id": 1567,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.019,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1572,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1577,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.02,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1582,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.007,
+      "status": "SAT"
+    },
+    {
+      "id": 1587,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.803,
+      "status": "SAT"
+    },
+    {
+      "id": 1592,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1597,
+      "heading_own_var": 26,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.017,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1602,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1607,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.642,
+      "status": "SAT"
+    },
+    {
+      "id": 1612,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.608,
+      "status": "SAT"
+    },
+    {
+      "id": 1617,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.56,
+      "status": "SAT"
+    },
+    {
+      "id": 1622,
+      "heading_own_var": 27,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1627,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 1.26,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1632,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.028,
+      "status": "SAT"
+    },
+    {
+      "id": 1637,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.976,
+      "status": "SAT"
+    },
+    {
+      "id": 1642,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1647,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1652,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1657,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.209,
+      "status": "SAT"
+    },
+    {
+      "id": 1662,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.838,
+      "status": "SAT"
+    },
+    {
+      "id": 1667,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1672,
+      "heading_own_var": 27,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.02,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1677,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1682,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.632,
+      "status": "SAT"
+    },
+    {
+      "id": 1687,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.64,
+      "status": "SAT"
+    },
+    {
+      "id": 1692,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.642,
+      "status": "SAT"
+    },
+    {
+      "id": 1697,
+      "heading_own_var": 28,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1702,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.017,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1707,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.016,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1712,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.814,
+      "status": "SAT"
+    },
+    {
+      "id": 1717,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1722,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1727,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1732,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.036,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1737,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 1.046,
+      "status": "SAT"
+    },
+    {
+      "id": 1742,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.011,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1747,
+      "heading_own_var": 28,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.02,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1752,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "SAT"
+    },
+    {
+      "id": 1757,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.625,
+      "status": "SAT"
+    },
+    {
+      "id": 1762,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.71,
+      "status": "SAT"
+    },
+    {
+      "id": 1767,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.683,
+      "status": "SAT"
+    },
+    {
+      "id": 1772,
+      "heading_own_var": 29,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1777,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1782,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1787,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.714,
+      "status": "SAT"
+    },
+    {
+      "id": 1792,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1797,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1802,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.027,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1807,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1812,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.904,
+      "status": "SAT"
+    },
+    {
+      "id": 1817,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1822,
+      "heading_own_var": 29,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1827,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1832,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.744,
+      "status": "SAT"
+    },
+    {
+      "id": 1837,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ]
+      ],
+      "wall_sec": 0.806,
+      "status": "SAT"
+    },
+    {
+      "id": 1842,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.591,
+      "status": "SAT"
+    },
+    {
+      "id": 1847,
+      "heading_own_var": 30,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 1852,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1857,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.033,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1862,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 2,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ]
+      ],
+      "wall_sec": 0.778,
+      "status": "SAT"
+    },
+    {
+      "id": 1867,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1872,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1877,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1882,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1887,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 5,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ]
+      ],
+      "wall_sec": 0.875,
+      "status": "SAT"
+    },
+    {
+      "id": 1892,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1897,
+      "heading_own_var": 30,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.744,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1902,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1907,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.615,
+      "status": "SAT"
+    },
+    {
+      "id": 1912,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.611,
+      "status": "SAT"
+    },
+    {
+      "id": 1917,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.66,
+      "status": "SAT"
+    },
+    {
+      "id": 1922,
+      "heading_own_var": 31,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.691,
+      "status": "SAT"
+    },
+    {
+      "id": 1927,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.752,
+      "status": "SAT"
+    },
+    {
+      "id": 1932,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.558,
+      "status": "SAT"
+    },
+    {
+      "id": 1937,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 1.081,
+      "status": "SAT"
+    },
+    {
+      "id": 1942,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.683,
+      "status": "SAT"
+    },
+    {
+      "id": 1947,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1952,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1957,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1962,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.044,
+      "status": "SAT"
+    },
+    {
+      "id": 1967,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.085,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1972,
+      "heading_own_var": 31,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1977,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.01,
+      "status": "UNSAT"
+    },
+    {
+      "id": 1982,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.614,
+      "status": "SAT"
+    },
+    {
+      "id": 1987,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.545,
+      "status": "SAT"
+    },
+    {
+      "id": 1992,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.61,
+      "status": "SAT"
+    },
+    {
+      "id": 1997,
+      "heading_own_var": 32,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.786,
+      "status": "SAT"
+    },
+    {
+      "id": 2002,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.78,
+      "status": "SAT"
+    },
+    {
+      "id": 2007,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.742,
+      "status": "SAT"
+    },
+    {
+      "id": 2012,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.646,
+      "status": "SAT"
+    },
+    {
+      "id": 2017,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.561,
+      "status": "SAT"
+    },
+    {
+      "id": 2022,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2027,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2032,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.025,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2037,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.357,
+      "status": "SAT"
+    },
+    {
+      "id": 2042,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.023,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2047,
+      "heading_own_var": 32,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2052,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2057,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.753,
+      "status": "SAT"
+    },
+    {
+      "id": 2062,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.632,
+      "status": "SAT"
+    },
+    {
+      "id": 2067,
+      "heading_own_var": 33,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.634,
+      "status": "SAT"
+    },
+    {
+      "id": 2072,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.779,
+      "status": "SAT"
+    },
+    {
+      "id": 2077,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.519,
+      "status": "SAT"
+    },
+    {
+      "id": 2082,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.879,
+      "status": "SAT"
+    },
+    {
+      "id": 2087,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.709,
+      "status": "SAT"
+    },
+    {
+      "id": 2092,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2097,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2102,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.026,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2107,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.754,
+      "status": "SAT"
+    },
+    {
+      "id": 2112,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2117,
+      "heading_own_var": 33,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2122,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.733,
+      "status": "SAT"
+    },
+    {
+      "id": 2127,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.816,
+      "status": "SAT"
+    },
+    {
+      "id": 2132,
+      "heading_own_var": 34,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.745,
+      "status": "SAT"
+    },
+    {
+      "id": 2137,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.901,
+      "status": "SAT"
+    },
+    {
+      "id": 2142,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.614,
+      "status": "SAT"
+    },
+    {
+      "id": 2147,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.586,
+      "status": "SAT"
+    },
+    {
+      "id": 2152,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.713,
+      "status": "SAT"
+    },
+    {
+      "id": 2157,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2162,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2167,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2172,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.266,
+      "status": "SAT"
+    },
+    {
+      "id": 2177,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.782,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2182,
+      "heading_own_var": 34,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2187,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.79,
+      "status": "SAT"
+    },
+    {
+      "id": 2192,
+      "heading_own_var": 35,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.675,
+      "status": "SAT"
+    },
+    {
+      "id": 2197,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.889,
+      "status": "SAT"
+    },
+    {
+      "id": 2202,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.467,
+      "status": "SAT"
+    },
+    {
+      "id": 2207,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.654,
+      "status": "SAT"
+    },
+    {
+      "id": 2212,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.738,
+      "status": "SAT"
+    },
+    {
+      "id": 2217,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2222,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.019,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2227,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.022,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2232,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.337,
+      "status": "SAT"
+    },
+    {
+      "id": 2237,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.024,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2242,
+      "heading_own_var": 35,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2247,
+      "heading_own_var": 36,
+      "x_sign": -1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 1,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ]
+      ],
+      "wall_sec": 0.85,
+      "status": "SAT"
+    },
+    {
+      "id": 2252,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.015,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2257,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.65,
+      "status": "SAT"
+    },
+    {
+      "id": 2262,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 4,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ]
+      ],
+      "wall_sec": 0.699,
+      "status": "SAT"
+    },
+    {
+      "id": 2267,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.824,
+      "status": "SAT"
+    },
+    {
+      "id": 2272,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.03,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2277,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.029,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2282,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.028,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2287,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 8,
+      "dangerous_xy": [
+        [
+          0,
+          2
+        ],
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ]
+      ],
+      "wall_sec": 1.119,
+      "status": "SAT"
+    },
+    {
+      "id": 2292,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.653,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2297,
+      "heading_own_var": 36,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2302,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.018,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2307,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.712,
+      "status": "SAT"
+    },
+    {
+      "id": 2312,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.734,
+      "status": "SAT"
+    },
+    {
+      "id": 2317,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.739,
+      "status": "SAT"
+    },
+    {
+      "id": 2322,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.014,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2327,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.292,
+      "status": "SAT"
+    },
+    {
+      "id": 2332,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.179,
+      "status": "SAT"
+    },
+    {
+      "id": 2337,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.96,
+      "status": "SAT"
+    },
+    {
+      "id": 2342,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.718,
+      "status": "SAT"
+    },
+    {
+      "id": 2347,
+      "heading_own_var": 37,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2352,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.774,
+      "status": "SAT"
+    },
+    {
+      "id": 2357,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.663,
+      "status": "SAT"
+    },
+    {
+      "id": 2362,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.609,
+      "status": "SAT"
+    },
+    {
+      "id": 2367,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.594,
+      "status": "SAT"
+    },
+    {
+      "id": 2372,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2377,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.089,
+      "status": "SAT"
+    },
+    {
+      "id": 2382,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.848,
+      "status": "SAT"
+    },
+    {
+      "id": 2387,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 1.032,
+      "status": "SAT"
+    },
+    {
+      "id": 2392,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 1.106,
+      "status": "SAT"
+    },
+    {
+      "id": 2397,
+      "heading_own_var": 38,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.009,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2402,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.537,
+      "status": "SAT"
+    },
+    {
+      "id": 2407,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.454,
+      "status": "SAT"
+    },
+    {
+      "id": 2412,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.566,
+      "status": "SAT"
+    },
+    {
+      "id": 2417,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 3,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          4,
+          0
+        ]
+      ],
+      "wall_sec": 0.662,
+      "status": "SAT"
+    },
+    {
+      "id": 2422,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": -1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 6,
+      "dangerous_xy": [
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ]
+      ],
+      "wall_sec": 0.013,
+      "status": "UNSAT"
+    },
+    {
+      "id": 2427,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "clear",
+      "forbidden_advisory_idx": 0,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.914,
+      "status": "SAT"
+    },
+    {
+      "id": 2432,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_left",
+      "forbidden_advisory_idx": 3,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.933,
+      "status": "SAT"
+    },
+    {
+      "id": 2437,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "strong_right",
+      "forbidden_advisory_idx": 4,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.768,
+      "status": "SAT"
+    },
+    {
+      "id": 2442,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_left",
+      "forbidden_advisory_idx": 1,
+      "n_states_covered": 14,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          1,
+          3
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          2,
+          3
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          3,
+          3
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ],
+        [
+          4,
+          3
+        ]
+      ],
+      "wall_sec": 0.815,
+      "status": "SAT"
+    },
+    {
+      "id": 2447,
+      "heading_own_var": 39,
+      "x_sign": 1,
+      "y_sign": 1,
+      "forbidden_advisory": "weak_right",
+      "forbidden_advisory_idx": 2,
+      "n_states_covered": 10,
+      "dangerous_xy": [
+        [
+          1,
+          2
+        ],
+        [
+          2,
+          0
+        ],
+        [
+          2,
+          1
+        ],
+        [
+          2,
+          2
+        ],
+        [
+          3,
+          0
+        ],
+        [
+          3,
+          1
+        ],
+        [
+          3,
+          2
+        ],
+        [
+          4,
+          0
+        ],
+        [
+          4,
+          1
+        ],
+        [
+          4,
+          2
+        ]
+      ],
+      "wall_sec": 0.012,
+      "status": "UNSAT"
+    }
+  ]
+}

--- a/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/run_acas_compositional_pipeline.py
+++ b/REPRODUCIBILITY/2026_TBA/examples/AcasXu_closed_loop/run_acas_compositional_pipeline.py
@@ -148,16 +148,22 @@ def run_smv_generation(ctx: dict) -> dict:
     tracemalloc.start()
     t0 = time.perf_counter()
 
-    _dsl.dsl_to_nuxmv(
-        str(ctx["metamodel"]),
-        str(ctx["tree_path"]),
-        str(ctx["base_smv_path"]),
-        False, False, False, False,
-        10000,       # recursion_limit
-        False,       # keep_stage_0
-        True,        # skip_grammar_check (--no_checks)
-        None,        # record_times
-    )
+    # ONNX paths in the tree are relative to tree/, so chdir there for parsing
+    _orig_cwd = os.getcwd()
+    os.chdir(str(ctx["tree_path"].parent))
+    try:
+        _dsl.dsl_to_nuxmv(
+            str(ctx["metamodel"]),
+            str(ctx["tree_path"]),
+            str(ctx["base_smv_path"]),
+            False, False, False, False,
+            10000,       # recursion_limit
+            False,       # keep_stage_0
+            True,        # skip_grammar_check (--no_checks)
+            None,        # record_times
+        )
+    finally:
+        os.chdir(_orig_cwd)
 
     wall_sec = time.perf_counter() - t0
     _, peak_traced = tracemalloc.get_traced_memory()
@@ -208,10 +214,10 @@ def _remove_nn_defines(smv: str) -> tuple[str, int]:
     for k in range(1, 6):
         var = f"network_{k}_1_stage_0"
         pattern = (
-            r"        " + re.escape(var) + r" :=\n"
-            r"            case\n"
+            r" +" + re.escape(var) + r" :=\s+"
+            r"case\s+"
             r".*?"
-            r"            esac;\n"
+            r"esac;\n"
         )
         before = smv.count("\n")
         smv, n = re.subn(pattern, "", smv, flags=re.DOTALL)
@@ -305,7 +311,7 @@ def run_smv_patch(ctx: dict) -> dict:
     contracts = _load_sat_contracts(ctx["contracts_path"], ctx["spec_path"])
 
     t0 = time.perf_counter()
-    smv = ctx["base_smv_path"].read_text(encoding="utf-8")
+    smv = ctx["base_smv_path"].read_text(encoding="utf-8").replace("\r\n", "\n")
 
     smv, lines_removed = _remove_nn_defines(smv)
     print(f"  Removed 5 NN DEFINE blocks ({lines_removed} lines)")


### PR DESCRIPTION
## Summary

Continuous contract verification results for NNs 2-5 using alpha-beta-CROWN with PGD-first falsification on an RTX 5090 (CUDA).

| NN | Network | SAT | UNSAT | TIMEOUT |
|----|---------|-----|-------|---------|
| 1 | aprev_clear | 269 | 221 | 0 | *(already on main)* |
| 2 | aprev_weak_right | 323 | 167 | 0 | |
| 3 | aprev_weak_left | 255 | 0 | **235** | |
| 4 | aprev_strong_right | 315 | 0 | **175** | |
| 5 | aprev_strong_left | 314 | 0 | **176** | |

NN_1/2 UNSAT contracts found instantly by PGD. NN_3/4/5 TIMEOUTs: PGD could not find counterexamples in the eps=1e-4 input region, and BaB could not prove SAT within 30s.

## Changes

- **`contracts/continuous_goals/enabled_pgd/aprev_*_crown_results.json`** — 4 new JSON files (NNs 2-5).
- **`run_acas_compositional_pipeline.py`** — Windows compatibility fixes:
  - `chdir` to `tree/` before `dsl_to_nuxmv` so ONNX relative paths resolve correctly.
  - Normalize `\r\n` to `\n` in SMV text before regex patching.
  - Relax NN DEFINE-block regex to tolerate extra blank lines in SMV output.

## Test plan

- [x] Ran all 5 NNs end-to-end on CUDA with PGD-first verification.
- [x] SMV generation and patching pass on Windows with the pipeline fixes.
- [ ] nuXmv step requires nuXmv binary on PATH (not tested on this machine).