### PR TITLE
Refresh grid world contract verification results (CUDA, RTX 5090)

### DIFF
--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/0995__6_18_0__200_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/0995__6_18_0__200_1.json
@@ -1,8 +1,8 @@
 {
   "onnx_path": "./networks/0995__6_18_0__200_1.onnx",
-  "timestamp": "2026-03-04T14:30:04.647700",
+  "timestamp": "2026-04-17T20:41:49.835763",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
-  "timeout_sec": 10,
+  "timeout_sec": 60,
   "summary": {
     "SAT": 17,
     "UNSAT": 0,
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 4,
@@ -68,7 +71,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 5,
@@ -83,7 +87,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 6,
@@ -98,7 +103,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 7,
@@ -113,7 +119,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +135,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +151,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 10,
@@ -158,7 +167,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +183,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 12,
@@ -188,7 +199,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 13,
@@ -203,7 +215,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 14,
@@ -218,7 +231,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 15,
@@ -233,7 +247,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 16,
@@ -248,7 +263,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 17,
@@ -263,7 +279,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +295,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 19,
@@ -293,7 +311,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 20,
@@ -308,7 +327,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 21,
@@ -323,7 +343,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 22,
@@ -338,7 +359,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 23,
@@ -353,7 +375,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 24,
@@ -368,7 +391,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +407,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +423,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 27,
@@ -413,7 +439,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +455,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 29,
@@ -443,7 +471,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 30,
@@ -458,7 +487,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 31,
@@ -473,7 +503,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 32,
@@ -488,7 +519,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 33,
@@ -503,7 +535,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     },
     {
       "id": 34,
@@ -518,7 +551,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 35,
@@ -533,7 +567,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 36,
@@ -548,7 +583,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +599,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 38,
@@ -578,7 +615,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "TIMEOUT"
+      "status": "TIMEOUT",
+      "counterexample": null
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/0996__6_18_0__200_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/0996__6_18_0__200_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/0996__6_18_0__200_1.onnx",
-  "timestamp": "2026-04-07T08:56:59.845306",
+  "timestamp": "2026-04-17T21:17:34.584022",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0100_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0100_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0100_1.onnx",
-  "timestamp": "2026-04-07T01:33:57.562382",
+  "timestamp": "2026-04-17T18:49:49.088610",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0150_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0150_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0150_1.onnx",
-  "timestamp": "2026-04-07T01:53:33.163066",
+  "timestamp": "2026-04-17T19:11:48.217803",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0200_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0200_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0200_1.onnx",
-  "timestamp": "2026-04-07T02:16:06.007963",
+  "timestamp": "2026-04-17T19:36:09.017292",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0250_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0250_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0250_1.onnx",
-  "timestamp": "2026-04-07T02:37:43.037053",
+  "timestamp": "2026-04-17T19:57:43.818341",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0300_1.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/disabled_pgd/1000__6_18_0__0300_1.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0300_1.onnx",
-  "timestamp": "2026-04-07T02:59:17.470661",
+  "timestamp": "2026-04-17T20:20:11.479778",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0100_1_pgd60.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0100_1_pgd60.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0100_1.onnx",
-  "timestamp": "2026-04-01T10:39:10.595969",
+  "timestamp": "2026-04-17T14:24:39.188822",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.001,
+        1.562172,
+        2.74706
+      ]
     },
     {
       "id": 4,
@@ -68,7 +76,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 5,
@@ -83,7 +92,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 6,
@@ -98,7 +108,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        -1e-05,
+        4.000249,
+        0.3757,
+        3.801602
+      ]
     },
     {
       "id": 7,
@@ -113,7 +129,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +145,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +161,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        5.999,
+        5.256144,
+        4.148273
+      ]
     },
     {
       "id": 10,
@@ -158,7 +182,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +198,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 12,
@@ -188,7 +214,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        0.001,
+        0.0,
+        5.251023
+      ]
     },
     {
       "id": 13,
@@ -203,7 +235,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.999045,
+        2.000979,
+        2.241924,
+        0.493831
+      ]
     },
     {
       "id": 14,
@@ -218,7 +256,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.99957,
+        3.999887,
+        1.793536,
+        2.504817
+      ]
     },
     {
       "id": 15,
@@ -233,7 +277,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 16,
@@ -248,7 +293,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 17,
@@ -263,7 +309,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +325,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000246,
+        3.000545,
+        2.753343,
+        3.847613
+      ]
     },
     {
       "id": 19,
@@ -293,7 +346,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.999,
+        2.999,
+        6.0,
+        3.697977
+      ]
     },
     {
       "id": 20,
@@ -308,7 +367,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        1.999,
+        0.0,
+        1.547052
+      ]
     },
     {
       "id": 21,
@@ -323,7 +388,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        4.001,
+        6.0,
+        3.883907
+      ]
     },
     {
       "id": 22,
@@ -338,7 +409,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999713,
+        5.999061,
+        4.252694,
+        1.2055
+      ]
     },
     {
       "id": 23,
@@ -353,7 +430,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        4.999,
+        3.025661,
+        5.276362
+      ]
     },
     {
       "id": 24,
@@ -368,7 +451,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +467,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +483,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999247,
+        0.000248,
+        2.694013,
+        3.167332
+      ]
     },
     {
       "id": 27,
@@ -413,7 +504,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +520,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 29,
@@ -443,7 +536,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999,
+        2.999,
+        6.0,
+        3.646821
+      ]
     },
     {
       "id": 30,
@@ -458,7 +557,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.000379,
+        4.999613,
+        5.328776,
+        4.99183
+      ]
     },
     {
       "id": 31,
@@ -473,7 +578,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000678,
+        4.999802,
+        5.895452,
+        5.482754
+      ]
     },
     {
       "id": 32,
@@ -488,7 +599,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999359,
+        4.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 33,
@@ -503,7 +620,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.00015,
+        5.999882,
+        4.748502,
+        4.201769
+      ]
     },
     {
       "id": 34,
@@ -518,7 +641,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 35,
@@ -533,7 +657,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.000177,
+        -0.000968,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 36,
@@ -548,7 +678,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +694,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 38,
@@ -578,7 +710,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.001,
+        3.999,
+        3.679724,
+        0.705385
+      ]
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0150_1_pgd60.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0150_1_pgd60.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0150_1.onnx",
-  "timestamp": "2026-04-01T10:40:10.011910",
+  "timestamp": "2026-04-17T14:33:38.398209",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 4,
@@ -68,7 +71,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 5,
@@ -83,7 +87,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 6,
@@ -98,7 +103,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        3.999,
+        1.353471,
+        3.124325
+      ]
     },
     {
       "id": 7,
@@ -113,7 +124,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +140,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +156,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 10,
@@ -158,7 +172,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +188,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 12,
@@ -188,7 +204,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.000229,
+        0.000712,
+        1.382743,
+        2.2329
+      ]
     },
     {
       "id": 13,
@@ -203,7 +225,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.001,
+        2.040831,
+        1.574357
+      ]
     },
     {
       "id": 14,
@@ -218,7 +246,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 15,
@@ -233,7 +262,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.000229,
+        3.000712,
+        1.382743,
+        2.2329
+      ]
     },
     {
       "id": 16,
@@ -248,7 +283,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        4.999,
+        3.238062,
+        0.5144
+      ]
     },
     {
       "id": 17,
@@ -263,7 +304,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +320,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        2.999,
+        2.092105,
+        3.907895
+      ]
     },
     {
       "id": 19,
@@ -293,7 +341,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.999,
+        3.001,
+        1.171453,
+        0.0
+      ]
     },
     {
       "id": 20,
@@ -308,7 +362,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        1.999,
+        0.0,
+        1.237457
+      ]
     },
     {
       "id": 21,
@@ -323,7 +383,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        4.001,
+        3.419121,
+        2.816708
+      ]
     },
     {
       "id": 22,
@@ -338,7 +404,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        6.001,
+        3.902296,
+        2.236548
+      ]
     },
     {
       "id": 23,
@@ -353,7 +425,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 24,
@@ -368,7 +441,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +457,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +473,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999713,
+        -0.000939,
+        4.252694,
+        1.2055
+      ]
     },
     {
       "id": 27,
@@ -413,7 +494,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +510,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999,
+        2.001,
+        4.542857,
+        0.0
+      ]
     },
     {
       "id": 29,
@@ -443,7 +531,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        2.999,
+        3.804959,
+        2.471924
+      ]
     },
     {
       "id": 30,
@@ -458,7 +552,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999359,
+        5.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 31,
@@ -473,7 +573,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000379,
+        4.999613,
+        5.328776,
+        4.99183
+      ]
     },
     {
       "id": 32,
@@ -488,7 +594,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999359,
+        4.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 33,
@@ -503,7 +615,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.000177,
+        5.999032,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 34,
@@ -518,7 +636,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 35,
@@ -533,7 +652,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999,
+        0.001,
+        5.978424,
+        3.326976
+      ]
     },
     {
       "id": 36,
@@ -548,7 +673,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +689,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 38,
@@ -578,7 +705,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.001,
+        3.999,
+        0.248974,
+        3.192425
+      ]
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0200_1_pgd60.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0200_1_pgd60.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0200_1.onnx",
-  "timestamp": "2026-04-01T10:41:09.966265",
+  "timestamp": "2026-04-17T14:36:52.562808",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 4,
@@ -68,7 +71,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        2.001,
+        3.080815,
+        0.555314
+      ]
     },
     {
       "id": 5,
@@ -83,7 +92,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 6,
@@ -98,7 +108,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        -0.000753,
+        4.000248,
+        2.694013,
+        3.167332
+      ]
     },
     {
       "id": 7,
@@ -113,7 +129,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +145,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +161,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 10,
@@ -158,7 +177,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +193,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.001,
+        1.001,
+        0.0,
+        2.538247
+      ]
     },
     {
       "id": 12,
@@ -188,7 +214,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.99999,
+        0.000249,
+        0.3757,
+        3.801602
+      ]
     },
     {
       "id": 13,
@@ -203,7 +235,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 14,
@@ -218,7 +251,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.000033,
+        3.999778,
+        1.00264,
+        4.431782
+      ]
     },
     {
       "id": 15,
@@ -233,7 +272,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.999,
+        0.057827,
+        1.779853
+      ]
     },
     {
       "id": 16,
@@ -248,7 +293,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        4.999,
+        2.442613,
+        3.506213
+      ]
     },
     {
       "id": 17,
@@ -263,7 +314,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +330,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999247,
+        3.000248,
+        2.694013,
+        3.167332
+      ]
     },
     {
       "id": 19,
@@ -293,7 +351,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.999,
+        2.999,
+        3.287766,
+        2.599921
+      ]
     },
     {
       "id": 20,
@@ -308,7 +372,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.000229,
+        2.000712,
+        1.382743,
+        2.2329
+      ]
     },
     {
       "id": 21,
@@ -323,7 +393,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.000177,
+        3.999032,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 22,
@@ -338,7 +414,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999,
+        5.999,
+        0.861153,
+        6.0
+      ]
     },
     {
       "id": 23,
@@ -353,7 +435,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 24,
@@ -368,7 +451,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +467,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +483,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000616,
+        0.000849,
+        3.701965,
+        0.480736
+      ]
     },
     {
       "id": 27,
@@ -413,7 +504,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +520,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999,
+        2.001,
+        6.0,
+        0.646804
+      ]
     },
     {
       "id": 29,
@@ -443,7 +541,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        2.999,
+        1.876619,
+        0.0
+      ]
     },
     {
       "id": 30,
@@ -458,7 +562,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999359,
+        5.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 31,
@@ -473,7 +583,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000678,
+        4.999802,
+        5.895452,
+        5.482754
+      ]
     },
     {
       "id": 32,
@@ -488,7 +604,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999359,
+        4.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 33,
@@ -503,7 +625,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.000177,
+        5.999032,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 34,
@@ -518,7 +646,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999,
+        0.999,
+        6.0,
+        0.0
+      ]
     },
     {
       "id": 35,
@@ -533,7 +667,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999,
+        0.001,
+        0.602413,
+        6.0
+      ]
     },
     {
       "id": 36,
@@ -548,7 +688,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +704,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 38,
@@ -578,7 +720,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.001,
+        3.999,
+        0.710963,
+        4.152273
+      ]
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0250_1_pgd60.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0250_1_pgd60.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0250_1.onnx",
-  "timestamp": "2026-04-01T10:42:09.156451",
+  "timestamp": "2026-04-17T14:37:29.313283",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.001,
+        0.0,
+        2.592442
+      ]
     },
     {
       "id": 4,
@@ -68,7 +76,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        2.001,
+        2.78514,
+        0.302075
+      ]
     },
     {
       "id": 5,
@@ -83,7 +97,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.001,
+        3.001,
+        4.646529,
+        0.0
+      ]
     },
     {
       "id": 6,
@@ -98,7 +118,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.000206,
+        4.000276,
+        3.655187,
+        1.708745
+      ]
     },
     {
       "id": 7,
@@ -113,7 +139,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +155,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +171,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        5.999,
+        3.464141,
+        6.0
+      ]
     },
     {
       "id": 10,
@@ -158,7 +192,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +208,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999,
+        1.001,
+        0.325654,
+        2.264078
+      ]
     },
     {
       "id": 12,
@@ -188,7 +229,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        0.001,
+        0.441772,
+        4.889759
+      ]
     },
     {
       "id": 13,
@@ -203,7 +250,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 14,
@@ -218,7 +266,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.99999,
+        4.000249,
+        0.3757,
+        3.801602
+      ]
     },
     {
       "id": 15,
@@ -233,7 +287,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.999,
+        1.353471,
+        0.0
+      ]
     },
     {
       "id": 16,
@@ -248,7 +308,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 17,
@@ -263,7 +324,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +340,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        2.999,
+        0.793069,
+        3.926
+      ]
     },
     {
       "id": 19,
@@ -293,7 +361,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.000378,
+        2.999613,
+        5.328776,
+        4.99183
+      ]
     },
     {
       "id": 20,
@@ -308,7 +382,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.99957,
+        1.999887,
+        1.793536,
+        2.504817
+      ]
     },
     {
       "id": 21,
@@ -323,7 +403,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999247,
+        4.000248,
+        2.694013,
+        3.167332
+      ]
     },
     {
       "id": 22,
@@ -338,7 +424,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        5.999,
+        3.262738,
+        2.458544
+      ]
     },
     {
       "id": 23,
@@ -353,7 +445,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 24,
@@ -368,7 +461,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +477,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +493,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000206,
+        0.000276,
+        3.655187,
+        1.708745
+      ]
     },
     {
       "id": 27,
@@ -413,7 +514,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +530,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 29,
@@ -443,7 +546,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.001,
+        3.001,
+        2.617896,
+        0.51013
+      ]
     },
     {
       "id": 30,
@@ -458,7 +567,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999359,
+        5.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 31,
@@ -473,7 +588,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000678,
+        4.999802,
+        5.895452,
+        5.482754
+      ]
     },
     {
       "id": 32,
@@ -488,7 +609,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999359,
+        4.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 33,
@@ -503,7 +630,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.000177,
+        5.999032,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 34,
@@ -518,7 +651,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 35,
@@ -533,7 +667,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999,
+        0.001,
+        5.846692,
+        3.217226
+      ]
     },
     {
       "id": 36,
@@ -548,7 +688,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +704,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 38,
@@ -578,7 +720,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0300_1_pgd60.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/continuous_goals/enabled_pgd/1000__6_18_0__0300_1_pgd60.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0300_1.onnx",
-  "timestamp": "2026-04-01T10:43:09.048030",
+  "timestamp": "2026-04-17T14:38:17.868341",
   "mode": "single-call, goal=[0,6]^2, drone EPS=0.001",
   "timeout_sec": 60,
   "summary": {
@@ -23,7 +23,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (0,1)  source (0,2)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 2,
@@ -38,7 +39,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,0)  source (2,0)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 3,
@@ -53,7 +55,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (1,2)  source (2,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 4,
@@ -68,7 +71,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,2)  source (0,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        2.001,
+        1.454162,
+        0.0
+      ]
     },
     {
       "id": 5,
@@ -83,7 +92,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,2)  source (1,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        1.001,
+        3.001,
+        4.673776,
+        0.415159
+      ]
     },
     {
       "id": 6,
@@ -98,7 +113,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,4)  source (0,4)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        0.001,
+        4.001,
+        3.697977,
+        2.279706
+      ]
     },
     {
       "id": 7,
@@ -113,7 +134,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,4)  source (1,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 8,
@@ -128,7 +150,8 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (1,4)  source (1,5)  forbid So",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 9,
@@ -143,7 +166,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (1,6)  source (0,6)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        -1e-05,
+        5.999295,
+        1.886882,
+        5.526231
+      ]
     },
     {
       "id": 10,
@@ -158,7 +187,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (1,6)  source (1,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 11,
@@ -173,7 +203,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,1)  source (3,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 12,
@@ -188,7 +219,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,1)  source (2,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.000229,
+        0.000712,
+        1.382743,
+        2.2329
+      ]
     },
     {
       "id": 13,
@@ -203,7 +240,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,1)  source (2,2)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        2.001,
+        2.209927,
+        0.398649
+      ]
     },
     {
       "id": 14,
@@ -218,7 +261,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (2,4)  source (3,4)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 15,
@@ -233,7 +277,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,4)  source (2,3)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 16,
@@ -248,7 +293,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (2,4)  source (2,5)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        4.999,
+        6.0,
+        4.627589
+      ]
     },
     {
       "id": 17,
@@ -263,7 +314,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (2,6)  source (2,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 18,
@@ -278,7 +330,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,3)  source (4,3)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.99999,
+        3.000249,
+        0.3757,
+        3.801602
+      ]
     },
     {
       "id": 19,
@@ -293,7 +351,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (3,3)  source (2,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.001,
+        3.001,
+        1.532876,
+        0.0
+      ]
     },
     {
       "id": 20,
@@ -308,7 +372,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,3)  source (3,2)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.000521,
+        2.000023,
+        0.65489,
+        4.307551
+      ]
     },
     {
       "id": 21,
@@ -323,7 +393,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (3,3)  source (3,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999045,
+        4.000979,
+        2.241924,
+        0.493831
+      ]
     },
     {
       "id": 22,
@@ -338,7 +414,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (3,6)  source (4,6)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 23,
@@ -353,7 +430,8 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (3,6)  source (3,5)  forbid No",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 24,
@@ -368,7 +446,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,1)  source (5,1)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 25,
@@ -383,7 +462,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,1)  source (3,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 26,
@@ -398,7 +478,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (4,1)  source (4,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        3.999779,
+        -0.00094,
+        0.502589,
+        5.938397
+      ]
     },
     {
       "id": 27,
@@ -413,7 +499,8 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (4,2)  source (5,2)  forbid We",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 28,
@@ -428,7 +515,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (4,2)  source (3,2)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        2.999,
+        2.001,
+        1.67478,
+        0.0
+      ]
     },
     {
       "id": 29,
@@ -443,7 +536,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (4,2)  source (4,3)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000616,
+        3.000849,
+        3.701965,
+        0.480736
+      ]
     },
     {
       "id": 30,
@@ -458,7 +557,13 @@
       "forbidden_dir": "We",
       "forbidden_dir_idx": 0,
       "description": "obstacle (5,5)  source (6,5)  forbid We",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.999359,
+        5.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 31,
@@ -473,7 +578,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (5,5)  source (4,5)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.000379,
+        4.999613,
+        5.328776,
+        4.99183
+      ]
     },
     {
       "id": 32,
@@ -488,7 +599,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (5,5)  source (5,4)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999359,
+        4.000649,
+        4.399442,
+        5.21961
+      ]
     },
     {
       "id": 33,
@@ -503,7 +620,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (5,5)  source (5,6)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        5.000177,
+        5.999032,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 34,
@@ -518,7 +641,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,1)  source (5,1)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 35,
@@ -533,7 +657,13 @@
       "forbidden_dir": "No",
       "forbidden_dir_idx": 2,
       "description": "obstacle (6,1)  source (6,0)  forbid No",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.000177,
+        -0.000968,
+        5.506464,
+        3.15614
+      ]
     },
     {
       "id": 36,
@@ -548,7 +678,8 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,2)  source (5,2)  forbid Ea",
-      "status": "SAT"
+      "status": "SAT",
+      "counterexample": null
     },
     {
       "id": 37,
@@ -563,7 +694,13 @@
       "forbidden_dir": "Ea",
       "forbidden_dir_idx": 1,
       "description": "obstacle (6,3)  source (5,3)  forbid Ea",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        4.999,
+        3.001,
+        2.465612,
+        0.0
+      ]
     },
     {
       "id": 38,
@@ -578,7 +715,13 @@
       "forbidden_dir": "So",
       "forbidden_dir_idx": 3,
       "description": "obstacle (6,3)  source (6,4)  forbid So",
-      "status": "UNSAT"
+      "status": "UNSAT",
+      "counterexample": [
+        6.000616,
+        4.000848,
+        3.701965,
+        0.480736
+      ]
     }
   ]
 }

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/0995__6_18_0__200_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/0995__6_18_0__200_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/0995__6_18_0__200_1.onnx",
-  "timestamp": "2026-04-07T19:51:38.694369",
+  "timestamp": "2026-04-17T18:01:59.523121",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/0996__6_18_0__200_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/0996__6_18_0__200_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/0996__6_18_0__200_1.onnx",
-  "timestamp": "2026-04-07T19:04:31.617486",
+  "timestamp": "2026-04-17T18:22:31.791267",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0100_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0100_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0100_1.onnx",
-  "timestamp": "2026-04-07T15:52:04.379533",
+  "timestamp": "2026-04-17T14:55:08.726803",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0150_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0150_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0150_1.onnx",
-  "timestamp": "2026-04-07T16:26:06.225547",
+  "timestamp": "2026-04-17T15:14:51.712407",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0200_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0200_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0200_1.onnx",
-  "timestamp": "2026-04-07T17:00:28.571602",
+  "timestamp": "2026-04-17T16:21:22.211767",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0250_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0250_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0250_1.onnx",
-  "timestamp": "2026-04-07T17:42:14.868220",
+  "timestamp": "2026-04-17T16:42:55.064759",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0300_1_discrete.json
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/contracts/discrete_goals/1000__6_18_0__0300_1_discrete.json
@@ -1,6 +1,6 @@
 {
   "onnx_path": "./networks/1000__6_18_0__0300_1.onnx",
-  "timestamp": "2026-04-07T18:21:23.882858",
+  "timestamp": "2026-04-17T17:07:22.577961",
   "mode": "discrete, 49 integer goals, drone EPS=0.0, goal EPS=0.0, timeout=5.0s per goal",
   "timeout_sec": 60,
   "summary": {

--- a/REPRODUCIBILITY/2026_TBA/examples/grid_world/verify_grid_world_contracts.py
+++ b/REPRODUCIBILITY/2026_TBA/examples/grid_world/verify_grid_world_contracts.py
@@ -392,8 +392,11 @@ def run_verification(cfg: dict[str, Any]) -> dict[str, Any]:
 
 def _self_rss_kb() -> int:
     """Peak RSS of this process so far (KB)."""
-    import resource  # noqa: PLC0415
-    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    try:
+        import resource  # noqa: PLC0415
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    except ImportError:
+        return 0  # Windows: resource module not available
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Re-ran all three grid world verification scripts on RTX 5090 (CUDA), updating the result JSONs.

### Continuous PGD-enabled (5 NNs, pgd_order=before, 60s timeout)

| NN | SAT | UNSAT | TIMEOUT |
|----|-----|-------|---------|
| 1000__6_18_0__0100_1 | 18 | 20 | 0 |
| 1000__6_18_0__0150_1 | 19 | 19 | 0 |
| 1000__6_18_0__0200_1 | 16 | 22 | 0 |
| 1000__6_18_0__0250_1 | 17 | 21 | 0 |
| 1000__6_18_0__0300_1 | 17 | 21 | 0 |

### Continuous BaB-only (7 NNs, --no-pgd, 60s timeout)

| NN | SAT | UNSAT | TIMEOUT |
|----|-----|-------|---------|
| 1000__6_18_0__0100_1 | 18 | 0 | 20 |
| 1000__6_18_0__0150_1 | 19 | 0 | 19 |
| 1000__6_18_0__0200_1 | 16 | 0 | 22 |
| 1000__6_18_0__0250_1 | 17 | 0 | 21 |
| 1000__6_18_0__0300_1 | 17 | 0 | 21 |
| 0995__6_18_0__200_1  | 17 | 0 | 21 |
| 0996__6_18_0__200_1  | 23 | 0 | 15 |

### Discrete (7 NNs, --discrete, 49 integer goals per contract)

| NN | SAT | UNSAT | TIMEOUT |
|----|-----|-------|---------|
| 1000__6_18_0__0100_1 | 38 | 0 | 0 |
| 1000__6_18_0__0150_1 | 38 | 0 | 0 |
| 1000__6_18_0__0200_1 | 38 | 0 | 0 |
| 1000__6_18_0__0250_1 | 38 | 0 | 0 |
| 1000__6_18_0__0300_1 | 38 | 0 | 0 |
| 0995__6_18_0__200_1  | 35 | 3 | 0 |
| 0996__6_18_0__200_1  | 34 | 4 | 0 |

### Observations

- **PGD-vs-BaB pattern matches the ACAS Xu work**: every contract that BaB times out on at 60s is instantly resolved as UNSAT by PGD. BaB cannot find counterexamples without gradient-based attacks.
- **Discrete mode**: all five 100% accurate NNs verify cleanly across all 49 integer goals × 38 contracts. The two slightly imperfect NNs (99.5%/99.6%) have 3 and 4 violated contracts respectively.

## Changes

- **20 contract result JSONs** under `contracts/{continuous_goals/{enabled_pgd,disabled_pgd},discrete_goals}/`.
- **`verify_grid_world_contracts.py`** — make `import resource` optional so the script runs on Windows (the `resource` module is Unix-only). Falls back to `0` for RSS reporting.

## Test plan

- [x] All 19 verification runs completed end-to-end on RTX 5090.
- [x] Result JSONs validate (each has 38 contracts; UNSAT contracts have non-empty `counterexample` fields).